### PR TITLE
Improve tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env*

--- a/flow.json
+++ b/flow.json
@@ -41,6 +41,28 @@
 			"address": "179b6b1cb6755e31",
 			"keys": "152a7e0a7b1bd4c0f873a7ae5aff7b342f582ee4e245af6dba62a26b0d5a7cbb",
 			"pubkey": "ba4602277bfa9f46a4155f1c078f3fa5864273a8233f5397c3a0cde84423ada984dca63a1e7fb75c9dfb70adbcdbce10c4c5b89f9139c2b67f5602d9098f7b30"
+		},
+		"minter-1": {
+			"address": "f8d6e0586b0a20c7",
+			"key": {
+                "type": "hex",
+                "index": 1,
+                "signatureAlgorithm": "ECDSA_P256",
+                "hashAlgorithm": "SHA3_256",
+                "privateKey": "948a03f367cf2586f0e85dd6c3bc28d24ff7371993521473440a320a62e1b447",
+                "pubkey": "e52f77245470ada70fd0c52b2b1625f871e925ee8b06cad5fde3f8dd7ff876e370155f8654b2bc49a048761fe2a4b278b8bf594a9479350987d39ce80b0dd87d"
+            }
+		},
+        "minter-2": {
+			"address": "f8d6e0586b0a20c7",
+            "key": {
+                "type": "hex",
+                "index": 2,
+                "signatureAlgorithm": "ECDSA_P256",
+                "hashAlgorithm": "SHA3_256",
+                "privateKey": "ee9e4e7648f5e53c1bb25b2e332c49cd6fc181f5e2baec796bff6d4167526c5a",
+                "pubkey": "ce27f48abc57d60c5a76654e49db5d8adbb1fe772b25442ed5213a77a715dbad3e6743096ac45c7025e203f2c1abdfda691b528d44391141df4875edd00fe91f"
+            }
 		}
 	},
 	"deployments": {

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "typescript": "^4.3.5",
     "wait-port": "^0.2.9"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "volta": {
+    "node": "14.17.4"
+  }
 }

--- a/scripts/get_permission.cdc
+++ b/scripts/get_permission.cdc
@@ -1,0 +1,5 @@
+import DCAPermission from "../contracts/DCAPermission.cdc"
+
+pub fun main(address: Address): { DCAPermission.Role: Bool }? {
+    return DCAPermission.getAllPermissions()[address]
+}

--- a/tests/admin/add_minter.test.ts
+++ b/tests/admin/add_minter.test.ts
@@ -1,0 +1,68 @@
+import { createEmulator, FlowEmulator } from "../utils/emulator"
+import { accounts } from '../../flow.json'
+import { address, bool, dicaa, enumUint8, event, events, optional, uint8 } from "../utils/args"
+
+let emulator: FlowEmulator
+beforeAll(async () => {
+    emulator = await createEmulator()
+    emulator.signer('emulator-account').transactions('transactions/permission/init_permission_receiver.cdc')
+    emulator.transactions('transactions/owner/add_admin.cdc', address(accounts["emulator-account"].address))
+})
+
+afterAll(() => {
+    emulator?.terminate()
+})
+
+beforeEach(() => {
+    emulator.signer('emulator-user-1').transactions('transactions/permission/init_permission_receiver.cdc')
+    emulator.signer('emulator-user-2').transactions('transactions/permission/init_permission_receiver.cdc')
+})
+
+afterEach(() => {
+    emulator.signer('emulator-user-1').transactions('transactions/permission/destroy_permission_receiver.cdc')
+    emulator.signer('emulator-user-2').transactions('transactions/permission/destroy_permission_receiver.cdc')
+})
+
+// AdminはMinterを追加できる
+test('Admin can add Minter', () => {
+    expect(
+        emulator.transactions('transactions/admin/add_minter.cdc', address(accounts["emulator-user-1"].address))
+    ).toEqual({
+        authorizers: '[f8d6e0586b0a20c7]',
+        events: events(
+            event('A.f8d6e0586b0a20c7.DCAPermission.PermissionAdded', {
+                target: address(accounts["emulator-user-1"].address),
+                role: uint8(3) // minter
+            })
+        ),
+        id: expect.any(String),
+        payer: 'f8d6e0586b0a20c7',
+        payload: expect.any(String),
+        status: 'SEALED'
+    })
+
+    expect(
+        emulator.scripts('scripts/get_permission.cdc', address(accounts["emulator-user-1"].address))
+    ).toEqual(optional(
+        dicaa([{
+            key: enumUint8('A.f8d6e0586b0a20c7.DCAPermission.Role', 3),
+            value: bool(true)
+        }])
+    ))
+})
+
+// AdminではないユーザーはMinterを追加できない
+test('Non-Admin users cannot add Minter', () => {
+    expect(() =>
+        emulator.signer('emulator-user-1').transactions('transactions/admin/add_minter.cdc', address(accounts["emulator-user-1"].address))
+    ).toThrowError('error: pre-condition failed: Roles not given cannot be borrowed')
+})
+
+// Adminは既存のMinterを追加できない
+test('Admin cannot add an existing Minter', () => {
+    emulator.transactions('transactions/admin/add_minter.cdc', address(accounts["emulator-user-2"].address))
+
+    expect(() =>
+        emulator.transactions('transactions/admin/add_minter.cdc', address(accounts["emulator-user-2"].address))
+    ).toThrowError('error: pre-condition failed: Existing roles are not added')
+})

--- a/tests/admin/add_operator.test.ts
+++ b/tests/admin/add_operator.test.ts
@@ -1,0 +1,68 @@
+import { createEmulator, FlowEmulator } from "../utils/emulator"
+import { accounts } from '../../flow.json'
+import { address, bool, dicaa, enumUint8, event, events, optional, uint8 } from "../utils/args"
+
+let emulator: FlowEmulator
+beforeAll(async () => {
+    emulator = await createEmulator()
+    emulator.signer('emulator-account').transactions('transactions/permission/init_permission_receiver.cdc')
+    emulator.transactions('transactions/owner/add_admin.cdc', address(accounts["emulator-account"].address))
+})
+
+afterAll(() => {
+    emulator?.terminate()
+})
+
+beforeEach(() => {
+    emulator.signer('emulator-user-1').transactions('transactions/permission/init_permission_receiver.cdc')
+    emulator.signer('emulator-user-2').transactions('transactions/permission/init_permission_receiver.cdc')
+})
+
+afterEach(() => {
+    emulator.signer('emulator-user-1').transactions('transactions/permission/destroy_permission_receiver.cdc')
+    emulator.signer('emulator-user-2').transactions('transactions/permission/destroy_permission_receiver.cdc')
+})
+
+// AdminはOperatorを追加できる
+test('Admin can add Operator', () => {
+    expect(
+        emulator.transactions('transactions/admin/add_operator.cdc', address(accounts["emulator-user-1"].address))
+    ).toEqual({
+        authorizers: '[f8d6e0586b0a20c7]',
+        events: events(
+            event('A.f8d6e0586b0a20c7.DCAPermission.PermissionAdded', {
+                target: address(accounts["emulator-user-1"].address),
+                role: uint8(2) // operator
+            })
+        ),
+        id: expect.any(String),
+        payer: 'f8d6e0586b0a20c7',
+        payload: expect.any(String),
+        status: 'SEALED'
+    })
+
+    expect(
+        emulator.scripts('scripts/get_permission.cdc', address(accounts["emulator-user-1"].address))
+    ).toEqual(optional(
+        dicaa([{
+            key: enumUint8('A.f8d6e0586b0a20c7.DCAPermission.Role', 2),
+            value: bool(true)
+        }])
+    ))
+})
+
+// AdminではないユーザーはOperatorを追加できない
+test('Non-Admin users cannot add Operator', () => {
+    expect(() =>
+        emulator.signer('emulator-user-1').transactions('transactions/admin/add_operator.cdc', address(accounts["emulator-user-1"].address))
+    ).toThrowError('error: pre-condition failed: Roles not given cannot be borrowed')
+})
+
+// Adminは既存のOperatorを追加できない
+test('Admin cannot add an existing Operator', () => {
+    emulator.transactions('transactions/admin/add_operator.cdc', address(accounts["emulator-user-2"].address))
+
+    expect(() =>
+        emulator.transactions('transactions/admin/add_operator.cdc', address(accounts["emulator-user-2"].address))
+    ).toThrowError('error: pre-condition failed: Existing roles are not added')
+})

--- a/tests/admin/remove_minter.test.ts
+++ b/tests/admin/remove_minter.test.ts
@@ -1,0 +1,63 @@
+import { createEmulator, FlowEmulator } from "../utils/emulator"
+import { accounts } from '../../flow.json'
+import { address, event, events, optional, uint8 } from "../utils/args"
+
+let emulator: FlowEmulator
+beforeAll(async () => {
+    emulator = await createEmulator()
+    emulator.signer('emulator-account').transactions('transactions/permission/init_permission_receiver.cdc')
+    emulator.transactions('transactions/owner/add_admin.cdc', address(accounts["emulator-account"].address))
+})
+
+afterAll(() => {
+    emulator?.terminate()
+})
+
+beforeEach(() => {
+    emulator.signer('emulator-user-1').transactions('transactions/permission/init_permission_receiver.cdc')
+    emulator.signer('emulator-user-2').transactions('transactions/permission/init_permission_receiver.cdc')
+})
+
+afterEach(() => {
+    emulator.signer('emulator-user-1').transactions('transactions/permission/destroy_permission_receiver.cdc')
+    emulator.signer('emulator-user-2').transactions('transactions/permission/destroy_permission_receiver.cdc')
+})
+
+// AdminはMinterを削除できる
+test('Admin can remove Minter', () => {
+    emulator.transactions('transactions/admin/add_minter.cdc', address(accounts["emulator-user-1"].address))
+
+    expect(
+        emulator.transactions('transactions/admin/remove_minter.cdc', address(accounts["emulator-user-1"].address))
+    ).toEqual({
+        authorizers: '[f8d6e0586b0a20c7]',
+        events: events(
+            event('A.f8d6e0586b0a20c7.DCAPermission.PermissionRemoved', {
+                target: address(accounts["emulator-user-1"].address),
+                role: uint8(3) // minter
+            })
+        ),
+        id: expect.any(String),
+        payer: 'f8d6e0586b0a20c7',
+        payload: expect.any(String),
+        status: 'SEALED'
+    })
+
+    expect(
+        emulator.scripts('scripts/get_permission.cdc', address(accounts["emulator-user-1"].address))
+    ).toEqual(optional(null))
+})
+
+// AdminではないユーザーはMinterを削除できない
+test('Non-Admin users cannot remove Minter', () => {
+    expect(() =>
+        emulator.signer("emulator-user-2").transactions('transactions/admin/remove_minter.cdc', address(accounts["emulator-user-1"].address))
+    ).toThrowError('error: pre-condition failed: Roles not given cannot be borrowed')
+})
+
+// Adminは重複してMinterを削除できない
+test('Owner cannot delete Minter more than once', () => {
+    expect(() =>
+        emulator.transactions('transactions/admin/remove_minter.cdc', address(accounts["emulator-user-1"].address))
+    ).toThrowError('error: pre-condition failed: Roles that do not exist cannot be removed')
+})

--- a/tests/admin/remove_operator.test.ts
+++ b/tests/admin/remove_operator.test.ts
@@ -1,0 +1,63 @@
+import { createEmulator, FlowEmulator } from "../utils/emulator"
+import { accounts } from '../../flow.json'
+import { address, event, events, optional, uint8 } from "../utils/args"
+
+let emulator: FlowEmulator
+beforeAll(async () => {
+    emulator = await createEmulator()
+    emulator.signer('emulator-account').transactions('transactions/permission/init_permission_receiver.cdc')
+    emulator.transactions('transactions/owner/add_admin.cdc', address(accounts["emulator-account"].address))
+})
+
+afterAll(() => {
+    emulator?.terminate()
+})
+
+beforeEach(() => {
+    emulator.signer('emulator-user-1').transactions('transactions/permission/init_permission_receiver.cdc')
+    emulator.signer('emulator-user-2').transactions('transactions/permission/init_permission_receiver.cdc')
+})
+
+afterEach(() => {
+    emulator.signer('emulator-user-1').transactions('transactions/permission/destroy_permission_receiver.cdc')
+    emulator.signer('emulator-user-2').transactions('transactions/permission/destroy_permission_receiver.cdc')
+})
+
+// AdminはOperatorを削除できる
+test('Admin can remove Operator', () => {
+    emulator.transactions('transactions/admin/add_operator.cdc', address(accounts["emulator-user-1"].address))
+
+    expect(
+        emulator.transactions('transactions/admin/remove_operator.cdc', address(accounts["emulator-user-1"].address))
+    ).toEqual({
+        authorizers: '[f8d6e0586b0a20c7]',
+        events: events(
+            event('A.f8d6e0586b0a20c7.DCAPermission.PermissionRemoved', {
+                target: address(accounts["emulator-user-1"].address),
+                role: uint8(2) // operator
+            })
+        ),
+        id: expect.any(String),
+        payer: 'f8d6e0586b0a20c7',
+        payload: expect.any(String),
+        status: 'SEALED'
+    })
+
+    expect(
+        emulator.scripts('scripts/get_permission.cdc', address(accounts["emulator-user-1"].address))
+    ).toEqual(optional(null))
+})
+
+// AdminではないユーザーはOperatorを削除できない
+test('Non-Admin users cannot remove Operator', () => {
+    expect(() =>
+        emulator.signer("emulator-user-2").transactions('transactions/admin/remove_operator.cdc', address(accounts["emulator-user-1"].address))
+    ).toThrowError('error: pre-condition failed: Roles not given cannot be borrowed')
+})
+
+// Adminは重複してOperatorを削除できない
+test('Owner cannot delete Operator more than once', () => {
+    expect(() =>
+        emulator.transactions('transactions/admin/remove_operator.cdc', address(accounts["emulator-user-1"].address))
+    ).toThrowError('error: pre-condition failed: Roles that do not exist cannot be removed')
+})

--- a/tests/minter/batch_mint_token.test.ts
+++ b/tests/minter/batch_mint_token.test.ts
@@ -1,4 +1,4 @@
-import { address, array, dicss, event, events, json, optional, string, uint32, uint64 } from "../utils/args"
+import { address, array, dicss, event, events, json, optional, resource, string, struct, uint32, uint64 } from "../utils/args"
 import { createEmulator, FlowEmulator } from "../utils/emulator"
 import flowConfig from '../../flow.json'
 
@@ -14,22 +14,31 @@ beforeAll(async () => {
     emulator.transactions('transactions/admin/add_minter.cdc', address(MINTER_ADDRESS))
     emulator.createItem({ itemId: 'test-item-1', version: 1, limit: 10, metadata: {} })
     emulator.createItem({ itemId: 'test-item-2', version: 1, limit: 30, metadata: {} })
-    emulator.transactions(`transactions/user/init_account.cdc --signer emulator-user-1`)
+    emulator.signer('emulator-user-1').transactions('transactions/user/init_account.cdc')
+    emulator.signer('emulator-user-1').transactions('transactions/permission/init_permission_receiver.cdc')
 })
 
 afterAll(() => {
     emulator?.terminate()
 })
 
-test('batch_mint_token succeeds', async () => {
-    const result = emulator!.exec(`flow transactions send transactions/minter/batch_mint_token.cdc \
-        --args-json '${json([address(USER1_ADDRESS), array([
+afterEach(() => {
+    emulator.signer('emulator-user-1').transactions('transactions/user/destroy_account.cdc')
+    emulator.signer('emulator-user-1').transactions('transactions/user/init_account.cdc')
+})
+
+// Minterは複数のNFTを一度にmintすることができる
+test('Minter can mint multiple NFTs at once', async () => {
+    const result = emulator.transactions(
+        'transactions/minter/batch_mint_token.cdc',
+        address(USER1_ADDRESS),
+        array([
             array([string('test-ref-1'), string('test-item-1'), dicss({ exInfo: 'exInfo for test-ref-1' })]),
             array([string('test-ref-2'), string('test-item-1'), dicss({ exInfo: 'exInfo for test-ref-2' })]),
             array([string('test-ref-3'), string('test-item-2')]),
             array([string('test-ref-4'), string('test-item-2')])
-        ])])}'
-    `)
+        ])
+    )
 
     expect(result).toEqual({
         authorizers: '[f8d6e0586b0a20c7]',
@@ -84,17 +93,113 @@ test('batch_mint_token succeeds', async () => {
         payload: expect.any(String),
         status: 'SEALED'
     })
+
+    expect(
+        emulator.scripts('scripts/get_tokens.cdc', address(USER1_ADDRESS))
+    ).toEqual(
+        array([
+            optional(resource('A.f8d6e0586b0a20c7.DigitalContentAsset.NFT', {
+                uuid: uint64(expect.any(String)),
+                id: uint64(1),
+                refId: string('test-ref-1'),
+                data: struct('A.f8d6e0586b0a20c7.DigitalContentAsset.NFTData', {
+                    serialNumber: uint32(1),
+                    itemId: string('test-item-1'),
+                    itemVersion: uint32(1),
+                    metadata: dicss({
+                        'exInfo': 'exInfo for test-ref-1'
+                    })
+                })
+            })),
+            optional(resource('A.f8d6e0586b0a20c7.DigitalContentAsset.NFT', {
+                uuid: uint64(expect.any(String)),
+                id: uint64(2),
+                refId: string('test-ref-2'),
+                data: struct('A.f8d6e0586b0a20c7.DigitalContentAsset.NFTData', {
+                    serialNumber: uint32(2),
+                    itemId: string('test-item-1'),
+                    itemVersion: uint32(1),
+                    metadata: dicss({
+                        'exInfo': 'exInfo for test-ref-2'
+                    })
+                })
+            })),
+            optional(resource('A.f8d6e0586b0a20c7.DigitalContentAsset.NFT', {
+                uuid: uint64(expect.any(String)),
+                id: uint64(3),
+                refId: string('test-ref-3'),
+                data: struct('A.f8d6e0586b0a20c7.DigitalContentAsset.NFTData', {
+                    serialNumber: uint32(1),
+                    itemId: string('test-item-2'),
+                    itemVersion: uint32(1),
+                    metadata: dicss({})
+                })
+            })),
+            optional(resource('A.f8d6e0586b0a20c7.DigitalContentAsset.NFT', {
+                uuid: uint64(expect.any(String)),
+                id: uint64(4),
+                refId: string('test-ref-4'),
+                data: struct('A.f8d6e0586b0a20c7.DigitalContentAsset.NFTData', {
+                    serialNumber: uint32(2),
+                    itemId: string('test-item-2'),
+                    itemVersion: uint32(1),
+                    metadata: dicss({})
+                })
+            }))
+        ])
+    )
 })
 
-test('batch_mint_token fails with non-existent itemId', async () => {
+// 存在しないitemIdを含んでいる場合はすべてのmintが失敗する
+test('All mint fails if it contains an itemId that does not exist', async () => {
     expect(() =>
-        emulator!.exec(`flow transactions send transactions/minter/batch_mint_token.cdc \
-            --args-json '${json([address(USER1_ADDRESS), array([
+        emulator.transactions(
+            'transactions/minter/batch_mint_token.cdc',
+            address(USER1_ADDRESS),
+            array([
                 array([string('test-ref-5'), string('test-item-1')]),
                 array([string('test-ref-6'), string('test-item-1')]),
                 array([string('test-ref-7'), string('unknown-item-id')]),
                 array([string('test-ref-8'), string('unknown-item-id')])
-            ])])}'
-        `)
-    ).toThrow('unexpectedly found nil while forcing an Optional value')
+            ])
+        )
+    ).toThrow('error: panic: That itemId does not exist')
+})
+
+// mint中にlimitを超過した場合はすべてのmintが失敗する
+test('If limit is exceeded during mint, all mint will fail', async () => {
+    const itemId = 'test-item-id-3'
+    emulator.createItem({ itemId, version: 1, limit: 2 })
+    expect(() =>
+        emulator.transactions(
+            'transactions/minter/batch_mint_token.cdc',
+            address(USER1_ADDRESS),
+            array([
+                array([string('test-ref-9'), string(itemId)]),
+                array([string('test-ref-10'), string(itemId)]),
+                array([string('test-ref-11'), string(itemId)]),
+                array([string('test-ref-12'), string(itemId)])
+            ])
+        )
+    ).toThrow('error: pre-condition failed: Fulfilled items cannot be mint')
+
+    expect(
+        emulator.scripts('scripts/get_tokens.cdc', address(USER1_ADDRESS))
+    ).toEqual(array([]))
+})
+
+// Minterでないユーザーはmintすることができない
+test('Non-Minter users cannot mint', () => {
+    const itemId = 'test-item-id-4'
+    emulator.createItem({ itemId, version: 1, limit: 2 })
+
+    expect(() =>
+        emulator.signer('emulator-user-1').transactions(
+            'transactions/minter/batch_mint_token.cdc',
+            address(USER1_ADDRESS),
+            array([
+                array([string('test-ref-13'), string(itemId)]),
+            ])
+        )
+    ).toThrow('error: pre-condition failed: Roles not given cannot be borrowed')
 })

--- a/tests/operator/update_item_active.test.ts
+++ b/tests/operator/update_item_active.test.ts
@@ -7,8 +7,9 @@ const MINTER_ADDRESS = '0x' + flowConfig.accounts["emulator-account"].address
 let emulator: FlowEmulator
 beforeAll(async () => {
     emulator = await createEmulator()
-    emulator.transactions('transactions/user/init_account.cdc --signer emulator-user-1')
+    emulator.signer('emulator-user-1').transactions('transactions/user/init_account.cdc')
     emulator.transactions('transactions/permission/init_permission_receiver.cdc')
+    emulator.signer('emulator-user-1').transactions('transactions/permission/init_permission_receiver.cdc')
     emulator.transactions('transactions/user/init_account.cdc')
     emulator.transactions('transactions/owner/add_admin.cdc', address(MINTER_ADDRESS))
     emulator.transactions('transactions/admin/add_operator.cdc', address(MINTER_ADDRESS))
@@ -74,4 +75,17 @@ test('Items updated to deactive cannot be mint', async () => {
             dicss({})
         )
     ).toThrowError('error: pre-condition failed: Only active items can be mint')
+})
+
+// OperatorではないユーザーはItemをactiveにできない
+test('Non-Operator users cannot activate Item', async () => {
+    emulator.createItem({itemId: 'test-item-id-5', version: 1, limit: 10, active: false})
+
+    expect(() =>
+        emulator.signer('emulator-user-1').transactions(
+            'transactions/operator/update_item_active.cdc',
+            string('test-item-id-5'),
+            bool(true)
+        )
+    ).toThrowError('error: pre-condition failed: Roles not given cannot be borrowed')
 })

--- a/tests/owner/add_admin.test.ts
+++ b/tests/owner/add_admin.test.ts
@@ -1,28 +1,35 @@
 import { createEmulator, FlowEmulator } from "../utils/emulator"
-import flowConfig from '../../flow.json'
-import { address, event, events, uint32, uint8 } from "../utils/args"
-
-const ADMIN_ADDRESS = '0x' + flowConfig.accounts["emulator-user-1"].address
+import { accounts } from '../../flow.json'
+import { address, bool, dicaa, enumUint8, event, events, optional, uint8 } from "../utils/args"
 
 let emulator: FlowEmulator
 beforeAll(async () => {
     emulator = await createEmulator()
-    emulator.transactions('transactions/permission/init_permission_receiver.cdc --signer emulator-user-1')
 })
 
 afterAll(() => {
     emulator?.terminate()
 })
 
-// OwnerはAdminを作ることができる
-test('Owner can create Admin', () => {
+beforeEach(() => {
+    emulator.signer('emulator-user-1').transactions('transactions/permission/init_permission_receiver.cdc')
+    emulator.signer('emulator-user-2').transactions('transactions/permission/init_permission_receiver.cdc')
+})
+
+afterEach(() => {
+    try { emulator.signer('emulator-user-1').transactions('transactions/permission/destroy_permission_receiver.cdc') } catch {}
+    try { emulator.signer('emulator-user-2').transactions('transactions/permission/destroy_permission_receiver.cdc') } catch {}
+})
+
+// OwnerはAdminを追加できる
+test('Owner can add Admin', () => {
     expect(
-        emulator.transactions('transactions/owner/add_admin.cdc', address(ADMIN_ADDRESS))
+        emulator.transactions('transactions/owner/add_admin.cdc', address(accounts["emulator-user-1"].address))
     ).toEqual({
         authorizers: '[f8d6e0586b0a20c7]',
         events: events(
             event('A.f8d6e0586b0a20c7.DCAPermission.PermissionAdded', {
-                target: address(ADMIN_ADDRESS),
+                target: address(accounts["emulator-user-1"].address),
                 role: uint8(1) // admin
             })
         ),
@@ -31,4 +38,29 @@ test('Owner can create Admin', () => {
         payload: expect.any(String),
         status: 'SEALED'
     })
+
+    expect(
+        emulator.scripts('scripts/get_permission.cdc', address(accounts["emulator-user-1"].address))
+    ).toEqual(optional(
+        dicaa([{
+            key: enumUint8('A.f8d6e0586b0a20c7.DCAPermission.Role', 1),
+            value: bool(true)
+        }])
+    ))
+})
+
+// OwnerではないユーザーはAdminを追加できない
+test('Non-Owner users cannot add Admin', () => {
+    expect(() =>
+        emulator.signer('emulator-user-1').transactions('transactions/owner/add_admin.cdc', address(accounts["emulator-user-2"].address))
+    ).toThrowError('error: panic: No owner resource in storage')
+})
+
+// Ownerは既存のAdminを追加できない
+test('Owner cannot add an existing Admin', () => {
+    emulator.transactions('transactions/owner/add_admin.cdc', address(accounts["emulator-user-2"].address))
+
+    expect(() =>
+        emulator.transactions('transactions/owner/add_admin.cdc', address(accounts["emulator-user-2"].address))
+    ).toThrowError('error: pre-condition failed: Existing roles are not added')
 })

--- a/tests/owner/remove_admin.test.ts
+++ b/tests/owner/remove_admin.test.ts
@@ -1,0 +1,54 @@
+import { createEmulator, FlowEmulator } from "../utils/emulator"
+import { accounts } from '../../flow.json'
+import { address, event, events, optional, uint8 } from "../utils/args"
+
+let emulator: FlowEmulator
+beforeAll(async () => {
+    emulator = await createEmulator()
+    emulator.signer('emulator-user-1').transactions('transactions/permission/init_permission_receiver.cdc')
+    emulator.signer('emulator-user-2').transactions('transactions/permission/init_permission_receiver.cdc')
+})
+
+afterAll(() => {
+    emulator?.terminate()
+})
+
+// OwnerはAdminを削除できる
+test('Owner can add Admin', () => {
+    emulator.transactions('transactions/owner/add_admin.cdc', address(accounts["emulator-user-1"].address))
+
+    expect(
+        emulator.transactions('transactions/owner/remove_admin.cdc', address(accounts["emulator-user-1"].address))
+    ).toEqual({
+        authorizers: '[f8d6e0586b0a20c7]',
+        events: events(
+            event('A.f8d6e0586b0a20c7.DCAPermission.PermissionRemoved', {
+                target: address(accounts["emulator-user-1"].address),
+                role: uint8(1) // admin
+            })
+        ),
+        id: expect.any(String),
+        payer: 'f8d6e0586b0a20c7',
+        payload: expect.any(String),
+        status: 'SEALED'
+    })
+
+    expect(
+        emulator.scripts('scripts/get_permission.cdc', address(accounts["emulator-user-1"].address))
+    ).toEqual(optional(null))
+})
+
+// OwnerではないユーザーはAdminを削除できない
+test('Non-Owner users cannot remove Admin', () => {
+    expect(() =>
+        emulator.signer("emulator-user-2").transactions('transactions/owner/remove_admin.cdc', address(accounts["emulator-user-1"].address))
+    ).toThrowError('error: panic: No owner resource in storage')
+})
+
+
+// Ownerは重複してAdminを削除できない
+test('Owner cannot delete Admin more than once', () => {
+    expect(() =>
+        emulator.transactions('transactions/owner/remove_admin.cdc', address(accounts["emulator-user-1"].address))
+    ).toThrowError('error: pre-condition failed: Roles that do not exist cannot be removed')
+})

--- a/tests/owner/remove_minter.test.ts
+++ b/tests/owner/remove_minter.test.ts
@@ -1,0 +1,54 @@
+import { createEmulator, FlowEmulator } from "../utils/emulator"
+import { accounts } from '../../flow.json'
+import { address, event, events, optional, uint8 } from "../utils/args"
+
+let emulator: FlowEmulator
+beforeAll(async () => {
+    emulator = await createEmulator()
+    emulator.signer('emulator-account').transactions('transactions/permission/init_permission_receiver.cdc')
+    emulator.signer('emulator-user-1').transactions('transactions/permission/init_permission_receiver.cdc')
+})
+
+afterAll(() => {
+    emulator?.terminate()
+})
+
+// OwnerはMinterを削除できる
+test('Owner can remove Minter', () => {
+    emulator.transactions('transactions/owner/add_admin.cdc', address(accounts["emulator-account"].address))
+    emulator.transactions('transactions/admin/add_minter.cdc', address(accounts["emulator-user-1"].address))
+
+    expect(
+        emulator.transactions('transactions/owner/remove_minter.cdc', address(accounts["emulator-user-1"].address))
+    ).toEqual({
+        authorizers: '[f8d6e0586b0a20c7]',
+        events: events(
+            event('A.f8d6e0586b0a20c7.DCAPermission.PermissionRemoved', {
+                target: address(accounts["emulator-user-1"].address),
+                role: uint8(3) // minter
+            })
+        ),
+        id: expect.any(String),
+        payer: 'f8d6e0586b0a20c7',
+        payload: expect.any(String),
+        status: 'SEALED'
+    })
+
+    expect(
+        emulator.scripts('scripts/get_permission.cdc', address(accounts["emulator-user-1"].address))
+    ).toEqual(optional(null))
+})
+
+// OwnerではないユーザーはMinterを削除できない
+test('Non-Owner users cannot remove Minter', () => {
+    expect(() =>
+        emulator.signer("emulator-user-2").transactions('transactions/owner/remove_minter.cdc', address(accounts["emulator-user-1"].address))
+    ).toThrowError('error: panic: No owner resource in storage')
+})
+
+// Ownerは重複してMinterを削除できない
+test('Owner cannot delete Minter more than once', () => {
+    expect(() =>
+        emulator.transactions('transactions/owner/remove_minter.cdc', address(accounts["emulator-user-1"].address))
+    ).toThrowError('error: pre-condition failed: Roles that do not exist cannot be removed')
+})

--- a/tests/owner/remove_operator.test.ts
+++ b/tests/owner/remove_operator.test.ts
@@ -1,0 +1,54 @@
+import { createEmulator, FlowEmulator } from "../utils/emulator"
+import { accounts } from '../../flow.json'
+import { address, event, events, optional, uint8 } from "../utils/args"
+
+let emulator: FlowEmulator
+beforeAll(async () => {
+    emulator = await createEmulator()
+    emulator.signer('emulator-account').transactions('transactions/permission/init_permission_receiver.cdc')
+    emulator.signer('emulator-user-1').transactions('transactions/permission/init_permission_receiver.cdc')
+})
+
+afterAll(() => {
+    emulator?.terminate()
+})
+
+// OwnerはOpeartorを削除できる
+test('Owner can remove Opeartor', () => {
+    emulator.transactions('transactions/owner/add_admin.cdc', address(accounts["emulator-account"].address))
+    emulator.transactions('transactions/admin/add_operator.cdc', address(accounts["emulator-user-1"].address))
+
+    expect(
+        emulator.transactions('transactions/owner/remove_operator.cdc', address(accounts["emulator-user-1"].address))
+    ).toEqual({
+        authorizers: '[f8d6e0586b0a20c7]',
+        events: events(
+            event('A.f8d6e0586b0a20c7.DCAPermission.PermissionRemoved', {
+                target: address(accounts["emulator-user-1"].address),
+                role: uint8(2) // opeartor
+            })
+        ),
+        id: expect.any(String),
+        payer: 'f8d6e0586b0a20c7',
+        payload: expect.any(String),
+        status: 'SEALED'
+    })
+
+    expect(
+        emulator.scripts('scripts/get_permission.cdc', address(accounts["emulator-user-1"].address))
+    ).toEqual(optional(null))
+})
+
+// OwnerではないユーザーはOperatorを削除できない
+test('Non-Owner users cannot remove Operator', () => {
+    expect(() =>
+        emulator.signer("emulator-user-2").transactions('transactions/owner/remove_operator.cdc', address(accounts["emulator-user-1"].address))
+    ).toThrowError('error: panic: No owner resource in storage')
+})
+
+// Ownerは重複してOperatorを削除できない
+test('Owner cannot delete Operator more than once', () => {
+    expect(() =>
+        emulator.transactions('transactions/owner/remove_operator.cdc', address(accounts["emulator-user-1"].address))
+    ).toThrowError('error: pre-condition failed: Roles that do not exist cannot be removed')
+})

--- a/tests/permission/destroy_permission_receiver.test.ts
+++ b/tests/permission/destroy_permission_receiver.test.ts
@@ -1,0 +1,31 @@
+import { createEmulator, FlowEmulator } from "../utils/emulator"
+
+let emulator: FlowEmulator
+beforeAll(async () => {
+    emulator = await createEmulator()
+})
+
+afterAll(() => {
+    emulator?.terminate()
+})
+
+beforeEach(() => {
+    emulator.signer('emulator-user-1').transactions('transactions/permission/init_permission_receiver.cdc')
+})
+
+// PermissionHolderは破棄することができる
+test('PermissionHolder can be destroyed', () => {
+    expect(
+        emulator.signer('emulator-user-1').transactions('transactions/permission/destroy_permission_receiver.cdc')
+    ).toBeTruthy()
+})
+
+
+// 重複してPermissionHolderを破棄することはできない
+test('PermissionHolder cannot be destroyed more than once', () => {
+    emulator.signer('emulator-user-1').transactions('transactions/permission/destroy_permission_receiver.cdc')
+
+    expect(() =>
+        emulator.signer('emulator-user-1').transactions('transactions/permission/destroy_permission_receiver.cdc')
+    ).toThrowError('error: panic: The account does not have a permission holder.')
+})

--- a/tests/permission/init_permission_receiver.test.ts
+++ b/tests/permission/init_permission_receiver.test.ts
@@ -1,0 +1,25 @@
+import { createEmulator, FlowEmulator } from "../utils/emulator"
+
+let emulator: FlowEmulator
+beforeAll(async () => {
+    emulator = await createEmulator()
+})
+
+afterAll(() => {
+    emulator?.terminate()
+})
+
+// 誰でもPermissionHolderを初期化することができる
+test('Anyone can initialize PermissionHolder', () => {
+    expect(
+        emulator.signer('emulator-user-1').transactions('transactions/permission/init_permission_receiver.cdc')
+    ).toBeTruthy()
+})
+
+
+// 重複してPermissionHolderを初期化することはできない
+test('PermissionHolder cannot be initialized more than once', () => {
+    expect(() =>
+        emulator.signer('emulator-user-1').transactions('transactions/permission/init_permission_receiver.cdc')
+    ).toThrowError('error: panic: The account has already been initialized.')
+})

--- a/tests/permission/non_admin.test.ts
+++ b/tests/permission/non_admin.test.ts
@@ -1,0 +1,41 @@
+import { createEmulator, FlowEmulator } from "../utils/emulator"
+import flowConfig from '../../flow.json'
+import { address } from "../utils/args"
+
+let emulator: FlowEmulator
+beforeAll(async () => {
+    emulator = await createEmulator()
+})
+
+afterAll(() => {
+    emulator?.terminate()
+})
+
+beforeEach(() => {
+    emulator.signer('emulator-user-1').transactions('transactions/permission/init_permission_receiver.cdc')
+    emulator.signer('emulator-user-2').transactions('transactions/permission/init_permission_receiver.cdc')
+})
+
+afterEach(() => {
+    try { emulator.signer('emulator-user-1').transactions('transactions/permission/destroy_permission_receiver.cdc') } catch {}
+    try { emulator.signer('emulator-user-2').transactions('transactions/permission/destroy_permission_receiver.cdc') } catch {}
+})
+
+// ロールを与えられていないユーザーはAdminとして活動できない
+test('Users who are not given the role cannot act as Admin', () => {
+    // As an Admin
+    expect(() =>
+        emulator.signer('emulator-user-1').transactions('transactions/admin/add_minter.cdc', address(flowConfig.accounts["emulator-user-2"].address))
+    ).toThrowError('error: pre-condition failed: Roles not given cannot be borrowed')
+})
+
+// ロールを削除されたユーザーはAdminとして活動できない
+test('User whose role has been deleted cannot act as Admin', () => {
+    emulator.transactions('transactions/owner/add_admin.cdc', address(flowConfig.accounts["emulator-user-1"].address))
+    emulator.transactions('transactions/owner/remove_admin.cdc', address(flowConfig.accounts["emulator-user-1"].address))
+
+    // As an Admin
+    expect(() =>
+        emulator.signer('emulator-user-1').transactions('transactions/admin/add_minter.cdc', address(flowConfig.accounts["emulator-user-2"].address))
+    ).toThrowError('error: pre-condition failed: Roles without permission cannot be used')
+})

--- a/tests/permission/non_minter.test.ts
+++ b/tests/permission/non_minter.test.ts
@@ -1,0 +1,62 @@
+import { createEmulator, FlowEmulator } from "../utils/emulator"
+import flowConfig from '../../flow.json'
+import { address, event, events, uint32, uint8, string, dicss, bool } from "../utils/args"
+
+let emulator: FlowEmulator
+beforeAll(async () => {
+    emulator = await createEmulator()
+})
+
+afterAll(() => {
+    emulator?.terminate()
+})
+
+beforeEach(() => {
+    emulator.signer('emulator-user-1').transactions('transactions/permission/init_permission_receiver.cdc')
+    emulator.signer('emulator-user-2').transactions('transactions/permission/init_permission_receiver.cdc')
+})
+
+afterEach(() => {
+    try {
+        emulator.signer('emulator-user-1').transactions('transactions/permission/destroy_permission_receiver.cdc')
+    } catch {
+        // NOP
+    }
+    try {
+        emulator.signer('emulator-user-2').transactions('transactions/permission/destroy_permission_receiver.cdc')
+    } catch {
+        // NOP
+    }
+})
+
+// ロールを与えられていないユーザーはMinterとして活動できない
+test('Users who are not given the role cannot act as Minter', () => {
+    // As an Minter
+    expect(() =>
+        emulator.signer('emulator-user-1').transactions(
+            'transactions/minter/mint_token.cdc',
+            address(flowConfig.accounts['emulator-user-2'].address),
+            string('test-ref-id-1'),
+            string('test-item-id-1'),
+            dicss({})
+        )
+    ).toThrowError('error: pre-condition failed: Roles not given cannot be borrowed')
+})
+
+// ロールを削除されたユーザーはMinterとして活動できない
+test('User whose role has been deleted cannot act as Minter', () => {
+    emulator.transactions('transactions/owner/add_admin.cdc', address(flowConfig.accounts["emulator-user-1"].address))
+    emulator.signer('emulator-user-1').transactions('transactions/admin/add_minter.cdc', address(flowConfig.accounts["emulator-user-1"].address))
+    emulator.transactions('transactions/owner/remove_minter.cdc', address(flowConfig.accounts["emulator-user-1"].address))
+
+    // As an Minter
+    expect(() =>
+        emulator.signer('emulator-user-1').transactions(
+            'transactions/minter/mint_token.cdc',
+            address(flowConfig.accounts['emulator-user-2'].address),
+            string('test-ref-id-1'),
+            string('test-item-id-1'),
+            dicss({})
+        )
+    ).toThrowError('error: pre-condition failed: Roles without permission cannot be used')
+})

--- a/tests/permission/non_operator.test.ts
+++ b/tests/permission/non_operator.test.ts
@@ -1,0 +1,64 @@
+import { createEmulator, FlowEmulator } from "../utils/emulator"
+import flowConfig from '../../flow.json'
+import { address, event, events, uint32, uint8, string, dicss, bool } from "../utils/args"
+
+let emulator: FlowEmulator
+beforeAll(async () => {
+    emulator = await createEmulator()
+})
+
+afterAll(() => {
+    emulator?.terminate()
+})
+
+beforeEach(() => {
+    emulator.signer('emulator-user-1').transactions('transactions/permission/init_permission_receiver.cdc')
+    emulator.signer('emulator-user-2').transactions('transactions/permission/init_permission_receiver.cdc')
+})
+
+afterEach(() => {
+    try {
+        emulator.signer('emulator-user-1').transactions('transactions/permission/destroy_permission_receiver.cdc')
+    } catch {
+        // NOP
+    }
+    try {
+        emulator.signer('emulator-user-2').transactions('transactions/permission/destroy_permission_receiver.cdc')
+    } catch {
+        // NOP
+    }
+})
+
+// ロールを与えられていないユーザーはOperatorとして活動できない
+test('Users who are not given the role cannot act as Operator', () => {
+    // As an Operator
+    expect(() =>
+        emulator.signer('emulator-user-1').transactions(
+            'transactions/operator/create_item.cdc',
+            string('test-item-id-1'),
+            uint32(1),
+            uint32(100),
+            dicss({}),
+            bool(true)
+        )
+    ).toThrowError('error: pre-condition failed: Roles not given cannot be borrowed')
+})
+
+// ロールを削除されたユーザーはOperatorとして活動できない
+test('User whose role has been deleted cannot act as Operator', () => {
+    emulator.transactions('transactions/owner/add_admin.cdc', address(flowConfig.accounts["emulator-user-1"].address))
+    emulator.signer('emulator-user-1').transactions('transactions/admin/add_operator.cdc', address(flowConfig.accounts["emulator-user-1"].address))
+    emulator.transactions('transactions/owner/remove_operator.cdc', address(flowConfig.accounts["emulator-user-1"].address))
+
+    // As an Operator
+    expect(() =>
+        emulator.signer('emulator-user-1').transactions(
+            'transactions/operator/create_item.cdc',
+            string('test-item-id-1'),
+            uint32(1),
+            uint32(100),
+            dicss({}),
+            bool(true)
+        )
+    ).toThrowError('error: pre-condition failed: Roles without permission cannot be used')
+})

--- a/tests/user/destroy_account.test.ts
+++ b/tests/user/destroy_account.test.ts
@@ -1,0 +1,25 @@
+import { createEmulator, FlowEmulator } from "../utils/emulator"
+
+let emulator: FlowEmulator
+beforeAll(async () => {
+    emulator = await createEmulator()
+})
+
+afterAll(() => {
+    emulator?.terminate()
+})
+
+// ユーザーはアカウントを破棄することができる
+test('User can destroy account', async () => {
+    emulator.signer('emulator-user-1').transactions('transactions/user/init_account.cdc')
+    expect(
+        emulator.signer('emulator-user-1').transactions('transactions/user/destroy_account.cdc')
+    ).toBeTruthy()
+})
+
+// アカウントを初期化していないユーザーはアカウントを破棄することができない
+test('Users who have not initialized their account cannot destroy their account', async () => {
+    expect(() =>
+        emulator.signer('emulator-user-2').transactions('transactions/user/destroy_account.cdc')
+    ).toThrowError('error: panic: That account has not been initialized.')
+})

--- a/tests/user/init_account.test.ts
+++ b/tests/user/init_account.test.ts
@@ -9,8 +9,17 @@ afterAll(() => {
     emulator?.terminate()
 })
 
-test('init emulator-user-1', async () => {
+// 誰でもユーザーとしてアカウントを初期化できる
+test('Anyone can initialize an account as a user', async () => {
     expect(
-        emulator.exec('flow transactions send transactions/user/init_account.cdc --signer emulator-user-1')
+        emulator.signer('emulator-user-1').transactions('transactions/user/init_account.cdc')
     ).toBeTruthy()
+})
+
+// 一度初期化したユーザーは重複してアカウントを初期化できない
+test('Once initialized, users cannot initialize their accounts more than once', async () => {
+    emulator.signer('emulator-user-2').transactions('transactions/user/init_account.cdc')
+    expect(() =>
+        emulator.signer('emulator-user-2').transactions('transactions/user/init_account.cdc')
+    ).toThrowError('error: panic: The account has already been initialized.')
 })

--- a/tests/user/transfer_token.test.ts
+++ b/tests/user/transfer_token.test.ts
@@ -1,10 +1,10 @@
-import { string, uint32, uint64, address, dicss, json, array, optional, resource, struct } from "../utils/args"
+import { string, uint32, uint64, address, dicss, json, array, optional, resource, struct, events, event } from "../utils/args"
 import { createEmulator, FlowEmulator } from "../utils/emulator"
-import flowConfig from '../../flow.json'
+import { accounts } from '../../flow.json'
 
-const MINTER_ADDRESS = '0x' + flowConfig.accounts["emulator-account"].address
-const USER1_ADDRESS = '0x' + flowConfig.accounts["emulator-user-1"].address
-const USER2_ADDRESS = '0x' + flowConfig.accounts["emulator-user-2"].address
+const MINTER_ADDRESS = accounts["emulator-account"].address
+const USER1_ADDRESS = accounts["emulator-user-1"].address
+const USER2_ADDRESS = accounts["emulator-user-2"].address
 
 let emulator: FlowEmulator
 beforeAll(async () => {
@@ -15,8 +15,8 @@ beforeAll(async () => {
     emulator.transactions('transactions/admin/add_operator.cdc', address(MINTER_ADDRESS))
     emulator.transactions('transactions/admin/add_minter.cdc', address(MINTER_ADDRESS))
 
-    emulator!.exec('flow transactions send transactions/user/init_account.cdc --signer emulator-user-1')
-    emulator!.exec('flow transactions send transactions/user/init_account.cdc --signer emulator-user-2')
+    emulator.signer('emulator-user-1').transactions('transactions/user/init_account.cdc')
+    emulator.signer('emulator-user-2').transactions('transactions/user/init_account.cdc')
 
     emulator.createItem({
         itemId: 'test-item-id-1', version: 1, limit: 10, metadata: {}
@@ -27,97 +27,83 @@ afterAll(() => {
     emulator?.terminate()
 })
 
-test('transfer_token succeeds', async () => {
-    emulator!.exec(`flow transactions send transactions/minter/mint_token.cdc \
-        --args-json '${json([address(USER1_ADDRESS), string('test-ref-id-1'), string('test-item-id-1'), dicss({})])}'
-    `)
+// ユーザーは別のユーザーにNFTを譲渡することができる
+test('A user can transfer an NFT to another user', async () => {
+    emulator.transactions('transactions/minter/mint_token.cdc',
+        address(USER1_ADDRESS),
+        string('test-ref-id-1'),
+        string('test-item-id-1'),
+        dicss({})
+    )
 
-    expect(emulator!.exec(`flow transactions send transactions/user/transfer_token.cdc \
-        --args-json '${json([uint64(1), address(USER2_ADDRESS)])}' \
-        --signer emulator-user-1
-    `)).toEqual({
+    expect(emulator.signer('emulator-user-1').transactions(
+        'transactions/user/transfer_token.cdc',
+        uint64(1),
+        address(USER2_ADDRESS)
+    )).toEqual({
         authorizers: expect.any(String),
-        events: [{
-            index: 0,
-            type: 'A.f8d6e0586b0a20c7.DigitalContentAsset.Withdraw',
-            values: {
-                type: 'Event',
-                value: {
-                    fields: [
-                        { name: 'id', value: { type: 'UInt64', value: '1'} },
-                        { name: 'from', value: { type: 'Optional', value: { type: 'Address', value: USER1_ADDRESS} } }
-                    ],
-                    id: 'A.f8d6e0586b0a20c7.DigitalContentAsset.Withdraw'
-                }
-            },
-        }, {
-            index: 1,
-            type: 'A.f8d6e0586b0a20c7.DigitalContentAsset.Deposit',
-            values: {
-                type: 'Event',
-                value: {
-                    fields: [
-                        { name: 'id', value: { type: 'UInt64', value: '1'} },
-                        { name: 'to', value: { type: 'Optional', value: { type: 'Address', value: USER2_ADDRESS} } }
-                    ],
-                    id: 'A.f8d6e0586b0a20c7.DigitalContentAsset.Deposit'
-                }
-            }
-        }],
+        events: events(
+            event('A.f8d6e0586b0a20c7.DigitalContentAsset.Withdraw', {
+                id: uint64(1),
+                from: optional(address(USER1_ADDRESS))
+            }),
+            event('A.f8d6e0586b0a20c7.DigitalContentAsset.Deposit', {
+                id: uint64(1),
+                to: optional(address(USER2_ADDRESS))
+            })
+        ),
         id: expect.any(String),
-        payer: USER1_ADDRESS.slice(2),
+        payer: USER1_ADDRESS,
         payload: expect.any(String),
         status: 'SEALED'
     })
 
-    expect(emulator!.exec(`flow scripts execute scripts/get_tokens.cdc \
-        --args-json '${json([address(USER1_ADDRESS)])}'
-    `)).toEqual({ type: 'Array', value: []})
+    expect(emulator.scripts(
+        'scripts/get_tokens.cdc',
+        address(USER1_ADDRESS)
+    )).toEqual({ type: 'Array', value: []})
 
-    expect(emulator!.exec(`flow scripts execute scripts/get_tokens.cdc \
-        --args-json '${json([address(USER2_ADDRESS)])}'
-    `)).toEqual({ type: 'Array', value: [{
-        type: 'Optional',
-        value: {
-            type: 'Resource',
-            value: {
-                fields: [
-                    { name: 'uuid', value: { type: 'UInt64', value: expect.any(String) } },
-                    { name: 'id', value: { type: 'UInt64', value: '1' }},
-                    { name: 'refId', value: { type: 'String', value: 'test-ref-id-1' }},
-                    { name: 'data', value: {
-                        type: 'Struct', value: {
-                            fields: [
-                                { name: 'serialNumber', value: { type: 'UInt32', value: '1' } },
-                                { name: 'itemId', value: { type: 'String', value: 'test-item-id-1' } },
-                                { name: 'itemVersion', value: { type: 'UInt32', value: '1' } },
-                                { name: 'metadata', value: { type: 'Dictionary', value: [] } },
-                            ],
-                            id: 'A.f8d6e0586b0a20c7.DigitalContentAsset.NFTData'
-                        }
-                    }},
-                ],
-                id: 'A.f8d6e0586b0a20c7.DigitalContentAsset.NFT'
-            }
-        }
-    }]})
+    expect(
+        emulator.scripts('scripts/get_tokens.cdc', address(USER2_ADDRESS))
+    ).toEqual(
+        array([
+            optional(
+                resource('A.f8d6e0586b0a20c7.DigitalContentAsset.NFT', {
+                uuid: uint64(expect.any(String)),
+                id: uint64(1),
+                refId: string('test-ref-id-1'),
+                data: struct('A.f8d6e0586b0a20c7.DigitalContentAsset.NFTData', {
+                    serialNumber: uint32(1),
+                    itemId: string('test-item-id-1'),
+                    itemVersion: uint32(1),
+                    metadata: dicss({})
+                })
+            })
+            )
+        ])
+    )
 })
 
-test('transfer_token fails with non-existent address', async () => {
-    emulator!.exec(`flow transactions send transactions/minter/mint_token.cdc \
-        --args-json '${json([address(USER1_ADDRESS), string('test-ref-id-2'), string('test-item-id-1'), dicss({})])}'
-    `)
+// ユーザーは存在しないユーザーにNFTを譲渡することはできない
+test('Users cannot transfer NFTs to non-existent users', async () => {
+    emulator.transactions('transactions/minter/mint_token.cdc',
+        address(USER1_ADDRESS),
+        string('test-ref-id-2'),
+        string('test-item-id-1'),
+        dicss({})
+    )
 
     expect(() =>
-        emulator!.exec(`flow transactions send transactions/user/transfer_token.cdc \
-            --args-json '${json([uint64(1), address('0x0000000000000000')])}' \
-            --signer emulator-user-1
-        `)
+        emulator.signer('emulator-user-1').transactions(
+            'transactions/user/transfer_token.cdc',
+            uint64(1), address('0x0000000000000000')
+        )
     ).toThrow('That withdrawID does not exist')
 
-    const result2 = emulator!.exec(`flow scripts execute scripts/get_tokens.cdc \
-        --args-json '${json([address(USER1_ADDRESS)])}'
-    `)
+    const result2 = emulator.scripts(
+        'scripts/get_tokens.cdc',
+        address(USER1_ADDRESS)
+    )
     expect(result2).toEqual(array([
         optional(
             resource('A.f8d6e0586b0a20c7.DigitalContentAsset.NFT', {
@@ -133,4 +119,14 @@ test('transfer_token fails with non-existent address', async () => {
             })
         )
     ]))
+})
+
+// ユーザーは所有していないNFTを他人に譲渡することはできない
+test('Users cannot transfer NFTs they do not own to others', async () => {
+    expect(() =>
+        emulator.signer('emulator-user-1').transactions(
+            'transactions/user/transfer_token.cdc',
+            uint64(123), address('0x0000000000000000')
+        )
+    ).toThrow('That withdrawID does not exist')
 })

--- a/tests/utils/args.ts
+++ b/tests/utils/args.ts
@@ -6,6 +6,19 @@ export function uint8(value: number) {
     return { type: 'UInt8', value: value.toString() }
 }
 
+export function enumUint8(id: string, value: number) {
+    return {
+        type: 'Enum',
+        value: {
+            fields: [{
+                name: 'rawValue',
+                value: uint8(value)
+            }],
+            id
+        }
+    }
+}
+
 export function uint32(value: number) {
     return { type: 'UInt32', value: value.toString() }
 }
@@ -41,7 +54,7 @@ export function dicaa(kvs: {key: any, value: any}[]) {
 export function address(value: string) {
     return {
         type: 'Address',
-        value: value
+        value: typeof value == 'string' && !value.startsWith('0x') ? '0x' + value : value
     }
 }
 

--- a/tests/utils/emulator.ts
+++ b/tests/utils/emulator.ts
@@ -130,5 +130,3 @@ export async function createEmulator(): Promise<FlowEmulator> {
         throw err
     }
 }
-
-jest.setTimeout(60000)

--- a/transactions/admin/remove_minter.cdc
+++ b/transactions/admin/remove_minter.cdc
@@ -1,0 +1,15 @@
+import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
+import DCAPermission from "../../contracts/DCAPermission.cdc"
+
+transaction(receiver: Address) {
+    let adminRef: &DCAPermission.Admin
+
+    prepare(account: AuthAccount) {
+        self.adminRef = account.borrow<&DCAPermission.Holder>(from: /storage/DCAPermission)?.borrowAdmin(by: account)
+            ?? panic("No admin in storage")
+    }
+
+    execute {
+        self.adminRef.removeMinter(receiver)
+    }
+}

--- a/transactions/admin/remove_operator.cdc
+++ b/transactions/admin/remove_operator.cdc
@@ -1,0 +1,15 @@
+import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
+import DCAPermission from "../../contracts/DCAPermission.cdc"
+
+transaction(receiver: Address) {
+    let adminRef: &DCAPermission.Admin
+
+    prepare(account: AuthAccount) {
+        self.adminRef = account.borrow<&DCAPermission.Holder>(from: /storage/DCAPermission)?.borrowAdmin(by: account)
+            ?? panic("No admin in storage")
+    }
+
+    execute {
+        self.adminRef.removeOperator(receiver)
+    }
+}

--- a/transactions/minter/add_public_key.cdc
+++ b/transactions/minter/add_public_key.cdc
@@ -1,0 +1,6 @@
+transaction(key: String) {
+    prepare(account: AuthAccount) {
+        let publicKey = PublicKey(publicKey: key.decodeHex(), signatureAlgorithm: SignatureAlgorithm.ECDSA_P256)
+        account.keys.add(publicKey: publicKey, hashAlgorithm: HashAlgorithm.SHA3_256, weight: 1000.0)
+    }
+}

--- a/transactions/minter/batch_mint_token.cdc
+++ b/transactions/minter/batch_mint_token.cdc
@@ -22,7 +22,7 @@ transaction(recipient: Address, args: [[AnyStruct]]) {
 
             assert(!refIds.contains(refId), message: "NFT with duplicate refId is not issued")
 
-            let item = DigitalContentAsset.getItem(itemId)!
+            let item = DigitalContentAsset.getItem(itemId) ?? panic("That itemId does not exist")
             let itemVersion = item.version
 
             let token <- self.minterRef.mintToken(

--- a/transactions/minter/mint_token.cdc
+++ b/transactions/minter/mint_token.cdc
@@ -13,7 +13,7 @@ transaction(recipient: Address, refId: String, itemId: String, metadata: { Strin
     }
 
     execute {
-        let item = DigitalContentAsset.getItem(itemId)!
+        let item = DigitalContentAsset.getItem(itemId) ?? panic("That itemId does not exist")
 
         let itemId = itemId
         let itemVersion = item.version

--- a/transactions/minter/remove_public_key.cdc
+++ b/transactions/minter/remove_public_key.cdc
@@ -1,0 +1,5 @@
+transaction(keyIndex: Int) {
+    prepare(account: AuthAccount) {
+        account.keys.revoke(keyIndex: keyIndex)
+    }
+}

--- a/transactions/owner/remove_admin.cdc
+++ b/transactions/owner/remove_admin.cdc
@@ -1,0 +1,15 @@
+import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
+import DCAPermission from "../../contracts/DCAPermission.cdc"
+
+transaction(receiver: Address) {
+    let ownerRef: &DCAPermission.Owner
+
+    prepare(owner: AuthAccount) {
+        self.ownerRef = owner.borrow<&DCAPermission.Owner>(from: /storage/DCAOwner)
+            ?? panic("No owner resource in storage")
+    }
+
+    execute {
+        self.ownerRef.removePermission(address: receiver, as: DCAPermission.Role.admin)
+    }
+}

--- a/transactions/owner/remove_minter.cdc
+++ b/transactions/owner/remove_minter.cdc
@@ -1,0 +1,15 @@
+import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
+import DCAPermission from "../../contracts/DCAPermission.cdc"
+
+transaction(receiver: Address) {
+    let ownerRef: &DCAPermission.Owner
+
+    prepare(owner: AuthAccount) {
+        self.ownerRef = owner.borrow<&DCAPermission.Owner>(from: /storage/DCAOwner)
+            ?? panic("No owner resource in storage")
+    }
+
+    execute {
+        self.ownerRef.removePermission(address: receiver, as: DCAPermission.Role.minter)
+    }
+}

--- a/transactions/owner/remove_operator.cdc
+++ b/transactions/owner/remove_operator.cdc
@@ -1,0 +1,15 @@
+import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
+import DCAPermission from "../../contracts/DCAPermission.cdc"
+
+transaction(receiver: Address) {
+    let ownerRef: &DCAPermission.Owner
+
+    prepare(owner: AuthAccount) {
+        self.ownerRef = owner.borrow<&DCAPermission.Owner>(from: /storage/DCAOwner)
+            ?? panic("No owner resource in storage")
+    }
+
+    execute {
+        self.ownerRef.removePermission(address: receiver, as: DCAPermission.Role.operator)
+    }
+}

--- a/transactions/permission/destroy_permission_receiver.cdc
+++ b/transactions/permission/destroy_permission_receiver.cdc
@@ -1,0 +1,9 @@
+import DCAPermission from "../../contracts/DCAPermission.cdc"
+
+transaction {
+    prepare(account: AuthAccount) {
+        let holder <- account.load<@DCAPermission.Holder>(from: /storage/DCAPermission) ?? panic("The account does not have a permission holder.")
+        destroy holder
+        account.unlink(/public/DCAPermission)
+    }
+}

--- a/transactions/user/destroy_account.cdc
+++ b/transactions/user/destroy_account.cdc
@@ -1,0 +1,9 @@
+import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
+
+transaction {
+    prepare(acct: AuthAccount) {
+        let collection <- acct.load<@DigitalContentAsset.Collection>(from: /storage/DCACollection)
+            ?? panic("That account has not been initialized.")
+        destroy collection
+    }
+}


### PR DESCRIPTION
## Summary

* Improved the unit test
* This PR **does not include any contract updates**
* Complemented transactions and scripts that may be needed for service use cases
  * Added transactions and scripts needed to manage permissions
  * Added flow-cli settings assuming that one minter address uses multiple public keys
* Added configuration for volta to implicitly use the recommended node version (this is just for convenience)

## Note

You can run unit tests with the `npm test` command, but keep in mind that .env requires `$FLOW_ADDRESS` and `$FLOW_PRIVATE_KEY`. These are values that you don't use in unit tests, but flow-cli checks these values when you start the emulator.

If you do not access testnet, please write the following value in `.env`:

```
FLOW_ADDRESS=0x012345678abcdef
FLOW_PRIVATE_KEY=0000000000000000000000000000000000000000000000000000000000000000
```