### PR TITLE
Rename DCA to FanTop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Digital Content Assets
+# FanTop contracts
 
 ## Introduction
 

--- a/contracts/FanTopPermission.cdc
+++ b/contracts/FanTopPermission.cdc
@@ -1,6 +1,6 @@
-import DigitalContentAsset from "./DigitalContentAsset.cdc"
+import FanTopToken from "./FanTopToken.cdc"
 
-pub contract DCAPermission {
+pub contract FanTopPermission {
     pub enum Role: UInt8 {
         pub case owner
         pub case admin
@@ -16,11 +16,11 @@ pub contract DCAPermission {
 
     pub resource Owner {
         pub fun addPermission(address: Address, as: Role) {
-            DCAPermission.addPermission(address, as: as)
+            FanTopPermission.addPermission(address, as: as)
         }
 
         pub fun removePermission(address: Address, as: Role) {
-            DCAPermission.removePermission(address, as: as)
+            FanTopPermission.removePermission(address, as: as)
         }
 
         pub fun addAdmin(receiver: &AnyResource{Receiver}) {
@@ -29,7 +29,7 @@ pub contract DCAPermission {
             }
 
             let recipient = receiver.owner!.address
-            let capability = DCAPermission.addPermission(recipient, as: Role.admin) as! Capability<&Admin>
+            let capability = FanTopPermission.addPermission(recipient, as: Role.admin) as! Capability<&Admin>
 
             receiver.receive(as: Role.admin, capability: capability)
         }
@@ -45,7 +45,7 @@ pub contract DCAPermission {
             }
 
             let recipient = receiver.owner!.address
-            let capability = DCAPermission.addPermission(recipient, as: Role.operator) as! Capability<&Operator>
+            let capability = FanTopPermission.addPermission(recipient, as: Role.operator) as! Capability<&Operator>
 
             receiver.receive(as: Role.operator, capability: capability)
         }
@@ -56,17 +56,17 @@ pub contract DCAPermission {
             }
 
             let recipient = receiver.owner!.address
-            let capability = DCAPermission.addPermission(recipient, as: Role.minter) as! Capability<&Minter>
+            let capability = FanTopPermission.addPermission(recipient, as: Role.minter) as! Capability<&Minter>
 
             receiver.receive(as: Role.minter, capability: capability)
         }
 
         pub fun removeOperator(_ address: Address) {
-            DCAPermission.removePermission(address, as: Role.operator)
+            FanTopPermission.removePermission(address, as: Role.operator)
         }
 
         pub fun removeMinter(_ address: Address) {
-            DCAPermission.removePermission(address, as: Role.minter)
+            FanTopPermission.removePermission(address, as: Role.minter)
         }
 
         access(contract) init() {
@@ -75,19 +75,19 @@ pub contract DCAPermission {
 
     pub resource Operator {
         pub fun createItem(itemId: String, version: UInt32, limit: UInt32, metadata: { String: String }, active: Bool) {
-            DigitalContentAsset.createItem(itemId: itemId, version: version, limit: limit, metadata: metadata, active: active)
+            FanTopToken.createItem(itemId: itemId, version: version, limit: limit, metadata: metadata, active: active)
         }
 
         pub fun updateMetadata(itemId: String, version: UInt32, metadata: { String: String }) {
-            DigitalContentAsset.updateMetadata(itemId: itemId, version: version, metadata: metadata)
+            FanTopToken.updateMetadata(itemId: itemId, version: version, metadata: metadata)
         }
 
         pub fun updateLimit(itemId: String, limit: UInt32) {
-            DigitalContentAsset.updateLimit(itemId: itemId, limit: limit)
+            FanTopToken.updateLimit(itemId: itemId, limit: limit)
         }
 
         pub fun updateActive(itemId: String, active: Bool) {
-            DigitalContentAsset.updateActive(itemId: itemId, active: active)
+            FanTopToken.updateActive(itemId: itemId, active: active)
         }
 
         access(contract) init() {
@@ -95,8 +95,8 @@ pub contract DCAPermission {
     }
 
     pub resource Minter {
-        pub fun mintToken(refId: String, itemId: String, itemVersion: UInt32, metadata: { String: String }): @DigitalContentAsset.NFT {
-            return <- DigitalContentAsset.mintToken(refId: refId, itemId: itemId, itemVersion: itemVersion, metadata: metadata)
+        pub fun mintToken(refId: String, itemId: String, itemVersion: UInt32, metadata: { String: String }): @FanTopToken.NFT {
+            return <- FanTopToken.mintToken(refId: refId, itemId: itemId, itemVersion: itemVersion, metadata: metadata)
         }
 
         access(contract) init() {
@@ -128,7 +128,7 @@ pub contract DCAPermission {
                 self.isValid(): "Invalid holder cannot be used"
                 self.recipient == by.address: "Only the owner can borrow"
                 self.roles.containsKey(Role.admin): "Roles not given cannot be borrowed"
-                DCAPermission.hasPermission(by.address, as: Role.admin): "Roles without permission cannot be used"
+                FanTopPermission.hasPermission(by.address, as: Role.admin): "Roles without permission cannot be used"
             }
 
             let role = self.roles[Role.admin]!
@@ -140,7 +140,7 @@ pub contract DCAPermission {
                 self.isValid(): "Invalid holder cannot be used"
                 self.recipient == by.address: "Only the owner can borrow"
                 self.roles.containsKey(Role.operator): "Roles not given cannot be borrowed"
-                DCAPermission.hasPermission(by.address, as: Role.operator): "Roles without permission cannot be used"
+                FanTopPermission.hasPermission(by.address, as: Role.operator): "Roles without permission cannot be used"
             }
 
             let role = self.roles[Role.operator]!
@@ -152,7 +152,7 @@ pub contract DCAPermission {
                 self.isValid(): "Invalid holder cannot be used"
                 self.recipient == by.address: "Only the owner can borrow"
                 self.roles.containsKey(Role.minter): "Roles not given cannot be borrowed"
-                DCAPermission.hasPermission(by.address, as: Role.minter): "Roles without permission cannot be used"
+                FanTopPermission.hasPermission(by.address, as: Role.minter): "Roles without permission cannot be used"
             }
 
             let role = self.roles[Role.minter]!
@@ -170,14 +170,14 @@ pub contract DCAPermission {
 
     access(self) fun addPermission(_ address: Address, as: Role): Capability {
         pre {
-            !DCAPermission.hasPermission(address, as: as): "Existing roles are not added"
+            !FanTopPermission.hasPermission(address, as: as): "Existing roles are not added"
         }
 
-        if let permission = DCAPermission.permissions[address] {
+        if let permission = FanTopPermission.permissions[address] {
             permission.insert(key: as, true)
-            DCAPermission.permissions.insert(key: address, permission)
+            FanTopPermission.permissions.insert(key: address, permission)
         } else {
-            DCAPermission.permissions.insert(key: address, { as: true })
+            FanTopPermission.permissions.insert(key: address, { as: true })
         }
 
         emit PermissionAdded(target: address, role: as.rawValue)
@@ -187,14 +187,14 @@ pub contract DCAPermission {
 
     access(self) fun removePermission(_ address: Address, as: Role) {
         pre {
-            DCAPermission.hasPermission(address, as: as): "Roles that do not exist cannot be removed"
+            FanTopPermission.hasPermission(address, as: as): "Roles that do not exist cannot be removed"
         }
-        let permission = DCAPermission.permissions.remove(key: address)!
+        let permission = FanTopPermission.permissions.remove(key: address)!
 
         permission.remove(key: as)
 
         if permission.keys.length > 0 {
-            DCAPermission.permissions.insert(key: address, permission)
+            FanTopPermission.permissions.insert(key: address, permission)
         }
 
         emit PermissionRemoved(target: address, role: as.rawValue)
@@ -209,25 +209,25 @@ pub contract DCAPermission {
     }
 
     pub fun hasPermission(_ address: Address, as: Role): Bool {
-        if let permission = DCAPermission.permissions[address] {
+        if let permission = FanTopPermission.permissions[address] {
             return permission[as] ?? false
         }
         return false
     }
 
     init() {
-        self.receiverStoragePath = /storage/DCAPermission
-        self.receiverPublicPath = /public/DCAPermission
+        self.receiverStoragePath = /storage/FanTopPermission
+        self.receiverPublicPath = /public/FanTopPermission
 
         self.permissions = {}
-        self.account.save<@Owner>(<- create Owner(), to: /storage/DCAOwner)
-        self.account.save<@Admin>(<- create Admin(), to: /storage/DCAAdmin)
-        self.account.save<@Operator>(<- create Operator(), to: /storage/DCAOperator)
-        self.account.save<@Minter>(<- create Minter(), to: /storage/DCAMinter)
+        self.account.save<@Owner>(<- create Owner(), to: /storage/FanTopOwner)
+        self.account.save<@Admin>(<- create Admin(), to: /storage/FanTopAdmin)
+        self.account.save<@Operator>(<- create Operator(), to: /storage/FanTopOperator)
+        self.account.save<@Minter>(<- create Minter(), to: /storage/FanTopMinter)
 
         self.capabilities = {}
-        self.capabilities[Role.admin] = self.account.link<&Admin>(/private/DCAAdmin, target: /storage/DCAAdmin)!
-        self.capabilities[Role.operator] = self.account.link<&Operator>(/private/DCAOperator, target: /storage/DCAOperator)!
-        self.capabilities[Role.minter] = self.account.link<&Minter>(/private/DCAMinter, target: /storage/DCAMinter)!
+        self.capabilities[Role.admin] = self.account.link<&Admin>(/private/FanTopAdmin, target: /storage/FanTopAdmin)!
+        self.capabilities[Role.operator] = self.account.link<&Operator>(/private/FanTopOperator, target: /storage/FanTopOperator)!
+        self.capabilities[Role.minter] = self.account.link<&Minter>(/private/FanTopMinter, target: /storage/FanTopMinter)!
     }
 }

--- a/contracts/FanTopToken.cdc
+++ b/contracts/FanTopToken.cdc
@@ -1,6 +1,6 @@
 import NonFungibleToken from "./NonFungibleToken.cdc"
 
-pub contract DigitalContentAsset: NonFungibleToken {
+pub contract FanTopToken: NonFungibleToken {
     pub var totalSupply: UInt64
 
     pub event ContractInitialized()
@@ -121,13 +121,13 @@ pub contract DigitalContentAsset: NonFungibleToken {
         access(self) let data: NFTData
 
         init(refId: String, data: NFTData) {
-            DigitalContentAsset.totalSupply = DigitalContentAsset.totalSupply + (1 as UInt64)
+            FanTopToken.totalSupply = FanTopToken.totalSupply + (1 as UInt64)
 
-            self.id = DigitalContentAsset.totalSupply
+            self.id = FanTopToken.totalSupply
             self.refId = refId
             self.data = data
 
-            emit DigitalContentAsset.TokenCreated(
+            emit FanTopToken.TokenCreated(
                 id: self.id,
                 refId: refId,
                 serialNumber: data.serialNumber,
@@ -137,7 +137,7 @@ pub contract DigitalContentAsset: NonFungibleToken {
         }
 
         destroy() {
-            emit DigitalContentAsset.TokenDestroyed(
+            emit FanTopToken.TokenDestroyed(
                 id: self.id,
                 refId: self.refId,
                 serialNumber: self.data.serialNumber,
@@ -175,7 +175,7 @@ pub contract DigitalContentAsset: NonFungibleToken {
     }
 
     pub fun createEmptyCollection(): @NonFungibleToken.Collection {
-        return <-create DigitalContentAsset.Collection()
+        return <-create FanTopToken.Collection()
     }
 
     pub resource interface CollectionPublic {
@@ -183,7 +183,7 @@ pub contract DigitalContentAsset: NonFungibleToken {
         pub fun batchDeposit(tokens: @NonFungibleToken.Collection)
         pub fun getIDs(): [UInt64]
         pub fun borrowNFT(id: UInt64): &NonFungibleToken.NFT
-        pub fun borrowDCAToken(id: UInt64): &DigitalContentAsset.NFT? {
+        pub fun borrowFanTopToken(id: UInt64): &FanTopToken.NFT? {
             post {
                 (result == nil) || (result?.id == id): "Invalid id"
             }
@@ -221,7 +221,7 @@ pub contract DigitalContentAsset: NonFungibleToken {
             pre {
                 !self.ownedNFTs.containsKey(token.id): "That id already exists"
             }
-            let token <- token as! @DigitalContentAsset.NFT
+            let token <- token as! @FanTopToken.NFT
             let id = token.id
             let refId = token.refId
             self.ownedNFTs[id] <-! token
@@ -245,9 +245,9 @@ pub contract DigitalContentAsset: NonFungibleToken {
             return &self.ownedNFTs[id] as &NonFungibleToken.NFT
         }
 
-        pub fun borrowDCAToken(id: UInt64): &DigitalContentAsset.NFT? {
+        pub fun borrowFanTopToken(id: UInt64): &FanTopToken.NFT? {
             let ref = &self.ownedNFTs[id] as auth &NonFungibleToken.NFT
-            return ref as? &DigitalContentAsset.NFT
+            return ref as? &FanTopToken.NFT
         }
 
         destroy() {
@@ -257,38 +257,38 @@ pub contract DigitalContentAsset: NonFungibleToken {
 
     access(account) fun createItem(itemId: String, version: UInt32, limit: UInt32, metadata: { String: String }, active: Bool): Item {
         pre {
-            !DigitalContentAsset.items.containsKey(itemId): "Admin cannot create existing items"
+            !FanTopToken.items.containsKey(itemId): "Admin cannot create existing items"
         }
         post {
-            DigitalContentAsset.items.containsKey(itemId): "items contains the created item"
+            FanTopToken.items.containsKey(itemId): "items contains the created item"
         }
 
         let item = Item(itemId: itemId, version: version, metadata: metadata, limit: limit, active: active)
-        DigitalContentAsset.items.insert(key: itemId, item)
+        FanTopToken.items.insert(key: itemId, item)
 
         return item
     }
 
     access(account) fun updateMetadata(itemId: String, version: UInt32, metadata: { String: String }) {
         pre {
-            DigitalContentAsset.items.containsKey(itemId): "Metadata of non-existent item cannot be updated"
+            FanTopToken.items.containsKey(itemId): "Metadata of non-existent item cannot be updated"
         }
-        DigitalContentAsset.items[itemId]!.setMetadata(version: version, metadata: metadata)
+        FanTopToken.items[itemId]!.setMetadata(version: version, metadata: metadata)
     }
 
     access(account) fun updateLimit(itemId: String, limit: UInt32) {
         pre {
-            DigitalContentAsset.items.containsKey(itemId): "Limit of non-existent item cannot be updated"
+            FanTopToken.items.containsKey(itemId): "Limit of non-existent item cannot be updated"
         }
-        DigitalContentAsset.items[itemId]!.setLimit(limit: limit)
+        FanTopToken.items[itemId]!.setLimit(limit: limit)
     }
 
     access(account) fun updateActive(itemId: String, active: Bool) {
         pre {
-            DigitalContentAsset.items.containsKey(itemId): "Limit of non-existent item cannot be updated"
-            DigitalContentAsset.items[itemId]!.active != active: "Item cannot be updated with the same value"
+            FanTopToken.items.containsKey(itemId): "Limit of non-existent item cannot be updated"
+            FanTopToken.items[itemId]!.active != active: "Item cannot be updated with the same value"
         }
-        DigitalContentAsset.items[itemId]!.setActive(active: active)
+        FanTopToken.items[itemId]!.setActive(active: active)
     }
 
     access(account) fun mintToken(
@@ -298,18 +298,18 @@ pub contract DigitalContentAsset: NonFungibleToken {
         metadata: { String: String }
     ): @NFT {
         pre {
-            DigitalContentAsset.items.containsKey(itemId) != nil: "That itemId does not exist"
-            itemVersion == DigitalContentAsset.items[itemId]!.version : "That itemVersion did not match the latest version"
-            !DigitalContentAsset.items[itemId]!.isFulfilled(): "Fulfilled items cannot be mint"
-            DigitalContentAsset.items[itemId]!.active: "Only active items can be mint"
+            FanTopToken.items.containsKey(itemId) != nil: "That itemId does not exist"
+            itemVersion == FanTopToken.items[itemId]!.version : "That itemVersion did not match the latest version"
+            !FanTopToken.items[itemId]!.isFulfilled(): "Fulfilled items cannot be mint"
+            FanTopToken.items[itemId]!.active: "Only active items can be mint"
         }
         post {
-            DigitalContentAsset.totalSupply == before(DigitalContentAsset.totalSupply) + 1: "totalSupply must be incremented"
-            DigitalContentAsset.items[itemId]!.mintedCount == before(DigitalContentAsset.items[itemId])!.mintedCount + 1: "mintedCount must be incremented"
-            DigitalContentAsset.items[itemId]!.isVersionLocked(): "item must be locked once mint"
+            FanTopToken.totalSupply == before(FanTopToken.totalSupply) + 1: "totalSupply must be incremented"
+            FanTopToken.items[itemId]!.mintedCount == before(FanTopToken.items[itemId])!.mintedCount + 1: "mintedCount must be incremented"
+            FanTopToken.items[itemId]!.isVersionLocked(): "item must be locked once mint"
         }
 
-        let serialNumber = DigitalContentAsset.items[itemId]!.countUp()
+        let serialNumber = FanTopToken.items[itemId]!.countUp()
 
         let data = NFTData(
             serialNumber: serialNumber,
@@ -334,8 +334,8 @@ pub contract DigitalContentAsset: NonFungibleToken {
     }
 
     init() {
-        self.collectionStoragePath = /storage/DCACollection
-        self.collectionPublicPath = /public/DCACollection
+        self.collectionStoragePath = /storage/FanTopTokenCollection
+        self.collectionPublicPath = /public/FanTopTokenCollection
 
         self.totalSupply = 0
         self.items = {}

--- a/flow.json
+++ b/flow.json
@@ -14,9 +14,9 @@
 				"emulator": "f8d6e0586b0a20c7"
 			}
 		},
-		"DigitalContentAsset": "./contracts/DigitalContentAsset.cdc",
-        "DCAMarket": "./contracts/DCAMarket.cdc",
-        "DCAPermission": "./contracts/DCAPermission.cdc"
+		"FanTopToken": "./contracts/FanTopToken.cdc",
+        "FanTopMarket": "./contracts/FanTopMarket.cdc",
+        "FanTopPermission": "./contracts/FanTopPermission.cdc"
 	},
 	"networks": {
 		"emulator": "127.0.0.1:3569",
@@ -68,15 +68,15 @@
 	"deployments": {
 		"testnet": {
 			"testnet-account": [
-				"DigitalContentAsset",
-				"DCAPermission"
+				"FanTopToken",
+				"FanTopPermission"
 			]
 		},
 		"emulator": {
 			"emulator-account": [
 				"NonFungibleToken",
-				"DigitalContentAsset",
-				"DCAPermission"
+				"FanTopToken",
+				"FanTopPermission"
 			]
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "smart-contracts",
   "version": "1.0.0",
-  "description": "Flow contract for Digital Content Assets",
+  "description": "Flow contract for FanTop",
   "main": "index.js",
   "directories": {
     "test": "tests"

--- a/scripts/get_all_permissions.cdc
+++ b/scripts/get_all_permissions.cdc
@@ -1,5 +1,5 @@
-import DCAPermission from "../contracts/DCAPermission.cdc"
+import FanTopPermission from "../contracts/FanTopPermission.cdc"
 
-pub fun main(): { Address: { DCAPermission.Role: Bool } } {
-    return DCAPermission.getAllPermissions()
+pub fun main(): { Address: { FanTopPermission.Role: Bool } } {
+    return FanTopPermission.getAllPermissions()
 }

--- a/scripts/get_item.cdc
+++ b/scripts/get_item.cdc
@@ -1,5 +1,5 @@
-import DigitalContentAsset from "../contracts/DigitalContentAsset.cdc"
+import FanTopToken from "../contracts/FanTopToken.cdc"
 
-pub fun main(itemId: String): DigitalContentAsset.Item? {
-    return DigitalContentAsset.getItem(itemId)
+pub fun main(itemId: String): FanTopToken.Item? {
+    return FanTopToken.getItem(itemId)
 }

--- a/scripts/get_item_ids.cdc
+++ b/scripts/get_item_ids.cdc
@@ -1,5 +1,5 @@
-import DigitalContentAsset from "../contracts/DigitalContentAsset.cdc"
+import FanTopToken from "../contracts/FanTopToken.cdc"
 
 pub fun main(): [String] {
-    return DigitalContentAsset.getItemIds()
+    return FanTopToken.getItemIds()
 }

--- a/scripts/get_item_versions.cdc
+++ b/scripts/get_item_versions.cdc
@@ -1,5 +1,5 @@
-import DigitalContentAsset from "../contracts/DigitalContentAsset.cdc"
+import FanTopToken from "../contracts/FanTopToken.cdc"
 
 pub fun main(itemId: String): [UInt32] {
-    return DigitalContentAsset.getItem(itemId)!.versions.keys
+    return FanTopToken.getItem(itemId)!.getVersions().keys
 }

--- a/scripts/get_items.cdc
+++ b/scripts/get_items.cdc
@@ -1,9 +1,9 @@
-import DigitalContentAsset from "../contracts/DigitalContentAsset.cdc"
+import FanTopToken from "../contracts/FanTopToken.cdc"
 
-pub fun main(): [DigitalContentAsset.Item] {
-    let items: [DigitalContentAsset.Item] = []
-    for id in DigitalContentAsset.getItemIds() {
-        items.append(DigitalContentAsset.getItem(id)!)
+pub fun main(): [FanTopToken.Item] {
+    let items: [FanTopToken.Item] = []
+    for id in FanTopToken.getItemIds() {
+        items.append(FanTopToken.getItem(id)!)
     }
     return items
 }

--- a/scripts/get_permission.cdc
+++ b/scripts/get_permission.cdc
@@ -1,5 +1,5 @@
-import DCAPermission from "../contracts/DCAPermission.cdc"
+import FanTopPermission from "../contracts/FanTopPermission.cdc"
 
-pub fun main(address: Address): { DCAPermission.Role: Bool }? {
-    return DCAPermission.getAllPermissions()[address]
+pub fun main(address: Address): { FanTopPermission.Role: Bool }? {
+    return FanTopPermission.getAllPermissions()[address]
 }

--- a/scripts/get_token.cdc
+++ b/scripts/get_token.cdc
@@ -1,7 +1,7 @@
-import DigitalContentAsset from "../contracts/DigitalContentAsset.cdc"
+import FanTopToken from "../contracts/FanTopToken.cdc"
 
-pub fun main(account: Address, id: UInt64): &DigitalContentAsset.NFT? {
-    let collectionRef = getAccount(account).getCapability(DigitalContentAsset.collectionPublicPath).borrow<&{DigitalContentAsset.CollectionPublic}>()
-        ?? panic("Could not get public DCA collection reference")
-    return collectionRef.borrowDCAToken(id: id)
+pub fun main(account: Address, id: UInt64): &FanTopToken.NFT? {
+    let collectionRef = getAccount(account).getCapability(FanTopToken.collectionPublicPath).borrow<&{FanTopToken.CollectionPublic}>()
+        ?? panic("Could not get public FanTopToken collection reference")
+    return collectionRef.borrowFanTopToken(id: id)
 }

--- a/scripts/get_tokens.cdc
+++ b/scripts/get_tokens.cdc
@@ -1,12 +1,12 @@
-import DigitalContentAsset from "../contracts/DigitalContentAsset.cdc"
+import FanTopToken from "../contracts/FanTopToken.cdc"
 
-pub fun main(account: Address): [&DigitalContentAsset.NFT] {
-    let collectionRef = getAccount(account).getCapability(DigitalContentAsset.collectionPublicPath).borrow<&{DigitalContentAsset.CollectionPublic}>()
-        ?? panic("Could not get public DCA collection reference")
+pub fun main(account: Address): [&FanTopToken.NFT] {
+    let collectionRef = getAccount(account).getCapability(FanTopToken.collectionPublicPath).borrow<&{FanTopToken.CollectionPublic}>()
+        ?? panic("Could not get public FanTopToken collection reference")
 
-    let refs: [&DigitalContentAsset.NFT] = []
+    let refs: [&FanTopToken.NFT] = []
     for id in collectionRef.getIDs() {
-        refs.append(collectionRef.borrowDCAToken(id: id)!)
+        refs.append(collectionRef.borrowFanTopToken(id: id)!)
     }
     return refs
 }

--- a/scripts/get_total_supply.cdc
+++ b/scripts/get_total_supply.cdc
@@ -1,5 +1,5 @@
-import DigitalContentAsset from "../contracts/DigitalContentAsset.cdc"
+import FanTopToken from "../contracts/FanTopToken.cdc"
 
 pub fun main(): UInt64 {
-    return DigitalContentAsset.totalSupply
+    return FanTopToken.totalSupply
 }

--- a/scripts/is_account_initialized.cdc
+++ b/scripts/is_account_initialized.cdc
@@ -1,5 +1,5 @@
-import DigitalContentAsset from "../contracts/DigitalContentAsset.cdc"
+import FanTopToken from "../contracts/FanTopToken.cdc"
 
 pub fun main(address: Address): Bool {
-    return getAccount(address).getCapability<&{DigitalContentAsset.CollectionPublic}>(/public/DCACollection).check()
+    return getAccount(address).getCapability<&{FanTopToken.CollectionPublic}>(/public/FanTopTokenCollection).check()
 }

--- a/tests/abuse/item.test.ts
+++ b/tests/abuse/item.test.ts
@@ -33,14 +33,14 @@ test('Item cannot be rewritten directly', async () => {
     expect(
         emulator.scripts('scripts/get_items.cdc')
     ).toEqual(array([
-        struct('A.f8d6e0586b0a20c7.DigitalContentAsset.Item', {
+        struct('A.f8d6e0586b0a20c7.FanTopToken.Item', {
             itemId: string('test-item-id-1'),
             version: uint32(5),
             mintedCount: uint32(0),
             limit: uint32(10),
             active: bool(true),
             versions: dicaa([{key: uint32(5), value:
-                struct('A.f8d6e0586b0a20c7.DigitalContentAsset.ItemData', {
+                struct('A.f8d6e0586b0a20c7.FanTopToken.ItemData', {
                     version: uint32(5),
                     originSerialNumber: uint32(1),
                     metadata: dicss({ itemName: 'Test Item 1@v5' })
@@ -65,14 +65,14 @@ test('Item.mintedCount cannot be rewritten directly', async () => {
     expect(
         emulator.scripts('scripts/get_item.cdc', string('test-item-id-2'))
     ).toEqual(optional(
-        struct('A.f8d6e0586b0a20c7.DigitalContentAsset.Item', {
+        struct('A.f8d6e0586b0a20c7.FanTopToken.Item', {
             itemId: string('test-item-id-2'),
             version: uint32(5),
             mintedCount: uint32(0),
             limit: uint32(10),
             active: bool(true),
             versions: dicaa([{key: uint32(5), value:
-                struct('A.f8d6e0586b0a20c7.DigitalContentAsset.ItemData', {
+                struct('A.f8d6e0586b0a20c7.FanTopToken.ItemData', {
                     version: uint32(5),
                     originSerialNumber: uint32(1),
                     metadata: dicss({ })
@@ -96,14 +96,14 @@ test('Item metadata cannot be rewritten directly', async () => {
     expect(
         emulator.scripts('scripts/get_item.cdc', string('test-item-id-3'))
     ).toEqual(optional(
-        struct('A.f8d6e0586b0a20c7.DigitalContentAsset.Item', {
+        struct('A.f8d6e0586b0a20c7.FanTopToken.Item', {
             itemId: string('test-item-id-3'),
             version: uint32(1),
             mintedCount: uint32(0),
             limit: uint32(0),
             active: bool(true),
             versions: dicaa([{key: uint32(1), value:
-                struct('A.f8d6e0586b0a20c7.DigitalContentAsset.ItemData', {
+                struct('A.f8d6e0586b0a20c7.FanTopToken.ItemData', {
                     version: uint32(1),
                     originSerialNumber: uint32(1),
                     metadata: dicss({ })

--- a/tests/abuse/nft.test.ts
+++ b/tests/abuse/nft.test.ts
@@ -52,11 +52,11 @@ test('Users cannot rewrite NFTs of others', () => {
 
     expect(
         emulator.scripts('scripts/get_token.cdc', address(ownerAddress), uint64(nftID))
-    ).toEqual(optional(optional(resource('A.f8d6e0586b0a20c7.DigitalContentAsset.NFT', {
+    ).toEqual(optional(optional(resource('A.f8d6e0586b0a20c7.FanTopToken.NFT', {
         uuid: uint64(expect.any(String)),
         id: uint64(1),
         refId: string('test-ref-id-1'),
-        data: struct('A.f8d6e0586b0a20c7.DigitalContentAsset.NFTData', {
+        data: struct('A.f8d6e0586b0a20c7.FanTopToken.NFTData', {
             serialNumber: uint32(1),
             itemId: string('test-item-id-1'),
             itemVersion: uint32(1),

--- a/tests/admin/add_minter.test.ts
+++ b/tests/admin/add_minter.test.ts
@@ -30,7 +30,7 @@ test('Admin can add Minter', () => {
     ).toEqual({
         authorizers: '[f8d6e0586b0a20c7]',
         events: events(
-            event('A.f8d6e0586b0a20c7.DCAPermission.PermissionAdded', {
+            event('A.f8d6e0586b0a20c7.FanTopPermission.PermissionAdded', {
                 target: address(accounts["emulator-user-1"].address),
                 role: uint8(3) // minter
             })
@@ -45,7 +45,7 @@ test('Admin can add Minter', () => {
         emulator.scripts('scripts/get_permission.cdc', address(accounts["emulator-user-1"].address))
     ).toEqual(optional(
         dicaa([{
-            key: enumUint8('A.f8d6e0586b0a20c7.DCAPermission.Role', 3),
+            key: enumUint8('A.f8d6e0586b0a20c7.FanTopPermission.Role', 3),
             value: bool(true)
         }])
     ))

--- a/tests/admin/add_operator.test.ts
+++ b/tests/admin/add_operator.test.ts
@@ -30,7 +30,7 @@ test('Admin can add Operator', () => {
     ).toEqual({
         authorizers: '[f8d6e0586b0a20c7]',
         events: events(
-            event('A.f8d6e0586b0a20c7.DCAPermission.PermissionAdded', {
+            event('A.f8d6e0586b0a20c7.FanTopPermission.PermissionAdded', {
                 target: address(accounts["emulator-user-1"].address),
                 role: uint8(2) // operator
             })
@@ -45,7 +45,7 @@ test('Admin can add Operator', () => {
         emulator.scripts('scripts/get_permission.cdc', address(accounts["emulator-user-1"].address))
     ).toEqual(optional(
         dicaa([{
-            key: enumUint8('A.f8d6e0586b0a20c7.DCAPermission.Role', 2),
+            key: enumUint8('A.f8d6e0586b0a20c7.FanTopPermission.Role', 2),
             value: bool(true)
         }])
     ))

--- a/tests/admin/remove_minter.test.ts
+++ b/tests/admin/remove_minter.test.ts
@@ -32,7 +32,7 @@ test('Admin can remove Minter', () => {
     ).toEqual({
         authorizers: '[f8d6e0586b0a20c7]',
         events: events(
-            event('A.f8d6e0586b0a20c7.DCAPermission.PermissionRemoved', {
+            event('A.f8d6e0586b0a20c7.FanTopPermission.PermissionRemoved', {
                 target: address(accounts["emulator-user-1"].address),
                 role: uint8(3) // minter
             })

--- a/tests/admin/remove_operator.test.ts
+++ b/tests/admin/remove_operator.test.ts
@@ -32,7 +32,7 @@ test('Admin can remove Operator', () => {
     ).toEqual({
         authorizers: '[f8d6e0586b0a20c7]',
         events: events(
-            event('A.f8d6e0586b0a20c7.DCAPermission.PermissionRemoved', {
+            event('A.f8d6e0586b0a20c7.FanTopPermission.PermissionRemoved', {
                 target: address(accounts["emulator-user-1"].address),
                 role: uint8(2) // operator
             })

--- a/tests/minter/batch_mint_token.test.ts
+++ b/tests/minter/batch_mint_token.test.ts
@@ -43,47 +43,47 @@ test('Minter can mint multiple NFTs at once', async () => {
     expect(result).toEqual({
         authorizers: '[f8d6e0586b0a20c7]',
         events: events(
-            event('A.f8d6e0586b0a20c7.DigitalContentAsset.TokenCreated', {
+            event('A.f8d6e0586b0a20c7.FanTopToken.TokenCreated', {
                 id: uint64(1),
                 refId: string('test-ref-1'),
                 serialNumber: uint32(1),
                 itemId: string('test-item-1'),
                 itemVersion: uint32(1)
             }),
-            event('A.f8d6e0586b0a20c7.DigitalContentAsset.Deposit', {
+            event('A.f8d6e0586b0a20c7.FanTopToken.Deposit', {
                 id: uint64(1),
                 to: optional(address(USER1_ADDRESS))
             }),
-            event('A.f8d6e0586b0a20c7.DigitalContentAsset.TokenCreated', {
+            event('A.f8d6e0586b0a20c7.FanTopToken.TokenCreated', {
                 id: uint64(2),
                 refId: string('test-ref-2'),
                 serialNumber: uint32(2),
                 itemId: string('test-item-1'),
                 itemVersion: uint32(1)
             }),
-            event('A.f8d6e0586b0a20c7.DigitalContentAsset.Deposit', {
+            event('A.f8d6e0586b0a20c7.FanTopToken.Deposit', {
                 id: uint64(2),
                 to: optional(address(USER1_ADDRESS))
             }),
-            event('A.f8d6e0586b0a20c7.DigitalContentAsset.TokenCreated', {
+            event('A.f8d6e0586b0a20c7.FanTopToken.TokenCreated', {
                 id: uint64(3),
                 refId: string('test-ref-3'),
                 serialNumber: uint32(1),
                 itemId: string('test-item-2'),
                 itemVersion: uint32(1)
             }),
-            event('A.f8d6e0586b0a20c7.DigitalContentAsset.Deposit', {
+            event('A.f8d6e0586b0a20c7.FanTopToken.Deposit', {
                 id: uint64(3),
                 to: optional(address(USER1_ADDRESS))
             }),
-            event('A.f8d6e0586b0a20c7.DigitalContentAsset.TokenCreated', {
+            event('A.f8d6e0586b0a20c7.FanTopToken.TokenCreated', {
                 id: uint64(4),
                 refId: string('test-ref-4'),
                 serialNumber: uint32(2),
                 itemId: string('test-item-2'),
                 itemVersion: uint32(1)
             }),
-            event('A.f8d6e0586b0a20c7.DigitalContentAsset.Deposit', {
+            event('A.f8d6e0586b0a20c7.FanTopToken.Deposit', {
                 id: uint64(4),
                 to: optional(address(USER1_ADDRESS))
             })
@@ -98,11 +98,11 @@ test('Minter can mint multiple NFTs at once', async () => {
         emulator.scripts('scripts/get_tokens.cdc', address(USER1_ADDRESS))
     ).toEqual(
         array([
-            optional(resource('A.f8d6e0586b0a20c7.DigitalContentAsset.NFT', {
+            optional(resource('A.f8d6e0586b0a20c7.FanTopToken.NFT', {
                 uuid: uint64(expect.any(String)),
                 id: uint64(1),
                 refId: string('test-ref-1'),
-                data: struct('A.f8d6e0586b0a20c7.DigitalContentAsset.NFTData', {
+                data: struct('A.f8d6e0586b0a20c7.FanTopToken.NFTData', {
                     serialNumber: uint32(1),
                     itemId: string('test-item-1'),
                     itemVersion: uint32(1),
@@ -111,11 +111,11 @@ test('Minter can mint multiple NFTs at once', async () => {
                     })
                 })
             })),
-            optional(resource('A.f8d6e0586b0a20c7.DigitalContentAsset.NFT', {
+            optional(resource('A.f8d6e0586b0a20c7.FanTopToken.NFT', {
                 uuid: uint64(expect.any(String)),
                 id: uint64(2),
                 refId: string('test-ref-2'),
-                data: struct('A.f8d6e0586b0a20c7.DigitalContentAsset.NFTData', {
+                data: struct('A.f8d6e0586b0a20c7.FanTopToken.NFTData', {
                     serialNumber: uint32(2),
                     itemId: string('test-item-1'),
                     itemVersion: uint32(1),
@@ -124,22 +124,22 @@ test('Minter can mint multiple NFTs at once', async () => {
                     })
                 })
             })),
-            optional(resource('A.f8d6e0586b0a20c7.DigitalContentAsset.NFT', {
+            optional(resource('A.f8d6e0586b0a20c7.FanTopToken.NFT', {
                 uuid: uint64(expect.any(String)),
                 id: uint64(3),
                 refId: string('test-ref-3'),
-                data: struct('A.f8d6e0586b0a20c7.DigitalContentAsset.NFTData', {
+                data: struct('A.f8d6e0586b0a20c7.FanTopToken.NFTData', {
                     serialNumber: uint32(1),
                     itemId: string('test-item-2'),
                     itemVersion: uint32(1),
                     metadata: dicss({})
                 })
             })),
-            optional(resource('A.f8d6e0586b0a20c7.DigitalContentAsset.NFT', {
+            optional(resource('A.f8d6e0586b0a20c7.FanTopToken.NFT', {
                 uuid: uint64(expect.any(String)),
                 id: uint64(4),
                 refId: string('test-ref-4'),
-                data: struct('A.f8d6e0586b0a20c7.DigitalContentAsset.NFTData', {
+                data: struct('A.f8d6e0586b0a20c7.FanTopToken.NFTData', {
                     serialNumber: uint32(2),
                     itemId: string('test-item-2'),
                     itemVersion: uint32(1),

--- a/tests/minter/mint_token.test.ts
+++ b/tests/minter/mint_token.test.ts
@@ -34,14 +34,14 @@ test('Minter can mint NFT', async () => {
     expect(result).toEqual({
         authorizers: expect.any(String),
         events: events(
-            event(expect.stringContaining('.DigitalContentAsset.TokenCreated'), {
+            event(expect.stringContaining('.FanTopToken.TokenCreated'), {
                 id: uint64(expect.any(String)),
                 refId: string('test-ref-id-1'),
                 serialNumber: uint32(1),
                 itemId: string('test-item-for-mint-token'),
                 itemVersion: uint32(1)
             }),
-            event(expect.stringContaining('DigitalContentAsset.Deposit'),{
+            event(expect.stringContaining('FanTopToken.Deposit'),{
                 id: uint64(expect.any(String)),
                 to: optional(address(expect.any(String)))
             })
@@ -54,11 +54,11 @@ test('Minter can mint NFT', async () => {
 
     expect(
         emulator.scripts('scripts/get_tokens.cdc', address(USER1_ADDRESS)
-    )).toEqual(array([optional(resource('A.f8d6e0586b0a20c7.DigitalContentAsset.NFT', {
+    )).toEqual(array([optional(resource('A.f8d6e0586b0a20c7.FanTopToken.NFT', {
         uuid: uint64(expect.any(String)),
         id: uint64(1),
         refId: string('test-ref-id-1'),
-        data: struct('A.f8d6e0586b0a20c7.DigitalContentAsset.NFTData', {
+        data: struct('A.f8d6e0586b0a20c7.FanTopToken.NFTData', {
             serialNumber: uint32(1),
             itemId: string('test-item-for-mint-token'),
             itemVersion: uint32(1),

--- a/tests/operator/create_item.test.ts
+++ b/tests/operator/create_item.test.ts
@@ -31,14 +31,14 @@ test('Operator can create Items', async () => {
     expect(emulator.scripts(
         'scripts/get_item.cdc',
         string('test-item-id-1')
-    )).toEqual(optional(struct('A.f8d6e0586b0a20c7.DigitalContentAsset.Item', {
+    )).toEqual(optional(struct('A.f8d6e0586b0a20c7.FanTopToken.Item', {
         itemId: string('test-item-id-1'),
         version: uint32(1),
         mintedCount: uint32(0),
         limit: uint32(0),
         active: bool(false),
         versions: dicaa([
-            { key: uint32(1), value: struct('A.f8d6e0586b0a20c7.DigitalContentAsset.ItemData', {
+            { key: uint32(1), value: struct('A.f8d6e0586b0a20c7.FanTopToken.ItemData', {
                 version: uint32(1),
                 originSerialNumber: uint32(1),
                 metadata: dicss({itemName: 'Test Item 1'})

--- a/tests/operator/update_item_limit.test.ts
+++ b/tests/operator/update_item_limit.test.ts
@@ -28,14 +28,14 @@ test('Item limits that have never been mint can be updated', async () => {
     expect(
         emulator.scripts('scripts/get_item.cdc', string('test-item-id-1'))
     ).toEqual(optional(
-        struct('A.f8d6e0586b0a20c7.DigitalContentAsset.Item', {
+        struct('A.f8d6e0586b0a20c7.FanTopToken.Item', {
             itemId: string('test-item-id-1'),
             version: uint32(1),
             mintedCount: uint32(0),
             limit: uint32(10),
             active: bool(true),
             versions: dicaa([{
-                key: uint32(1), value: struct('A.f8d6e0586b0a20c7.DigitalContentAsset.ItemData', {
+                key: uint32(1), value: struct('A.f8d6e0586b0a20c7.FanTopToken.ItemData', {
                     version: uint32(1),
                     originSerialNumber: uint32(1),
                     metadata: dicss({})

--- a/tests/operator/update_item_metadata.test.ts
+++ b/tests/operator/update_item_metadata.test.ts
@@ -25,14 +25,14 @@ test('Non-minted version of metadata can be updated with the same version', () =
     emulator.transactions('transactions/operator/update_item_metadata.cdc', string('test-item-id-1'), uint32(1), dicss({ 'versionName': 'First (overwritten)'}))
 
     expect(emulator.scripts('scripts/get_item.cdc', string('test-item-id-1'))).toEqual(optional(
-        struct('A.f8d6e0586b0a20c7.DigitalContentAsset.Item', {
+        struct('A.f8d6e0586b0a20c7.FanTopToken.Item', {
             itemId: string('test-item-id-1'),
             version: uint32(1),
             mintedCount: uint32(0),
             limit: uint32(1),
             active: bool(true),
             versions: dicaa([{
-                key: uint32(1), value: struct('A.f8d6e0586b0a20c7.DigitalContentAsset.ItemData', {
+                key: uint32(1), value: struct('A.f8d6e0586b0a20c7.FanTopToken.ItemData', {
                     version: uint32(1),
                     originSerialNumber: uint32(1),
                     metadata: dicss({ 'versionName': 'First (overwritten)'})
@@ -60,20 +60,20 @@ test('Minted version of metadata can be overridden with newer version of metadat
     emulator.transactions('transactions/operator/update_item_metadata.cdc', string('test-item-id-3'), uint32(2), dicss({ 'versionName': 'Second'}))
 
     expect(emulator.scripts('scripts/get_item.cdc', string('test-item-id-3'))).toEqual(optional(
-        struct('A.f8d6e0586b0a20c7.DigitalContentAsset.Item', {
+        struct('A.f8d6e0586b0a20c7.FanTopToken.Item', {
             itemId: string('test-item-id-3'),
             version: uint32(2),
             mintedCount: uint32(1),
             limit: uint32(1),
             active: bool(true),
             versions: dicaa([{
-                key: uint32(1), value: struct('A.f8d6e0586b0a20c7.DigitalContentAsset.ItemData', {
+                key: uint32(1), value: struct('A.f8d6e0586b0a20c7.FanTopToken.ItemData', {
                     version: uint32(1),
                     originSerialNumber: uint32(1),
                     metadata: dicss({ 'versionName': 'First'})
                 })
             }, {
-                key: uint32(2), value: struct('A.f8d6e0586b0a20c7.DigitalContentAsset.ItemData', {
+                key: uint32(2), value: struct('A.f8d6e0586b0a20c7.FanTopToken.ItemData', {
                     version: uint32(2),
                     originSerialNumber: uint32(2),
                     metadata: dicss({ 'versionName': 'Second'})

--- a/tests/owner/add_admin.test.ts
+++ b/tests/owner/add_admin.test.ts
@@ -28,7 +28,7 @@ test('Owner can add Admin', () => {
     ).toEqual({
         authorizers: '[f8d6e0586b0a20c7]',
         events: events(
-            event('A.f8d6e0586b0a20c7.DCAPermission.PermissionAdded', {
+            event('A.f8d6e0586b0a20c7.FanTopPermission.PermissionAdded', {
                 target: address(accounts["emulator-user-1"].address),
                 role: uint8(1) // admin
             })
@@ -43,7 +43,7 @@ test('Owner can add Admin', () => {
         emulator.scripts('scripts/get_permission.cdc', address(accounts["emulator-user-1"].address))
     ).toEqual(optional(
         dicaa([{
-            key: enumUint8('A.f8d6e0586b0a20c7.DCAPermission.Role', 1),
+            key: enumUint8('A.f8d6e0586b0a20c7.FanTopPermission.Role', 1),
             value: bool(true)
         }])
     ))

--- a/tests/owner/remove_admin.test.ts
+++ b/tests/owner/remove_admin.test.ts
@@ -22,7 +22,7 @@ test('Owner can add Admin', () => {
     ).toEqual({
         authorizers: '[f8d6e0586b0a20c7]',
         events: events(
-            event('A.f8d6e0586b0a20c7.DCAPermission.PermissionRemoved', {
+            event('A.f8d6e0586b0a20c7.FanTopPermission.PermissionRemoved', {
                 target: address(accounts["emulator-user-1"].address),
                 role: uint8(1) // admin
             })

--- a/tests/owner/remove_minter.test.ts
+++ b/tests/owner/remove_minter.test.ts
@@ -23,7 +23,7 @@ test('Owner can remove Minter', () => {
     ).toEqual({
         authorizers: '[f8d6e0586b0a20c7]',
         events: events(
-            event('A.f8d6e0586b0a20c7.DCAPermission.PermissionRemoved', {
+            event('A.f8d6e0586b0a20c7.FanTopPermission.PermissionRemoved', {
                 target: address(accounts["emulator-user-1"].address),
                 role: uint8(3) // minter
             })

--- a/tests/owner/remove_operator.test.ts
+++ b/tests/owner/remove_operator.test.ts
@@ -23,7 +23,7 @@ test('Owner can remove Opeartor', () => {
     ).toEqual({
         authorizers: '[f8d6e0586b0a20c7]',
         events: events(
-            event('A.f8d6e0586b0a20c7.DCAPermission.PermissionRemoved', {
+            event('A.f8d6e0586b0a20c7.FanTopPermission.PermissionRemoved', {
                 target: address(accounts["emulator-user-1"].address),
                 role: uint8(2) // opeartor
             })

--- a/tests/user/transfer_token.test.ts
+++ b/tests/user/transfer_token.test.ts
@@ -43,11 +43,11 @@ test('A user can transfer an NFT to another user', async () => {
     )).toEqual({
         authorizers: expect.any(String),
         events: events(
-            event('A.f8d6e0586b0a20c7.DigitalContentAsset.Withdraw', {
+            event('A.f8d6e0586b0a20c7.FanTopToken.Withdraw', {
                 id: uint64(1),
                 from: optional(address(USER1_ADDRESS))
             }),
-            event('A.f8d6e0586b0a20c7.DigitalContentAsset.Deposit', {
+            event('A.f8d6e0586b0a20c7.FanTopToken.Deposit', {
                 id: uint64(1),
                 to: optional(address(USER2_ADDRESS))
             })
@@ -68,11 +68,11 @@ test('A user can transfer an NFT to another user', async () => {
     ).toEqual(
         array([
             optional(
-                resource('A.f8d6e0586b0a20c7.DigitalContentAsset.NFT', {
+                resource('A.f8d6e0586b0a20c7.FanTopToken.NFT', {
                 uuid: uint64(expect.any(String)),
                 id: uint64(1),
                 refId: string('test-ref-id-1'),
-                data: struct('A.f8d6e0586b0a20c7.DigitalContentAsset.NFTData', {
+                data: struct('A.f8d6e0586b0a20c7.FanTopToken.NFTData', {
                     serialNumber: uint32(1),
                     itemId: string('test-item-id-1'),
                     itemVersion: uint32(1),
@@ -106,11 +106,11 @@ test('Users cannot transfer NFTs to non-existent users', async () => {
     )
     expect(result2).toEqual(array([
         optional(
-            resource('A.f8d6e0586b0a20c7.DigitalContentAsset.NFT', {
+            resource('A.f8d6e0586b0a20c7.FanTopToken.NFT', {
                 uuid: uint64(expect.any(String)),
                 id: uint64(2),
                 refId: string('test-ref-id-2'),
-                data: struct('A.f8d6e0586b0a20c7.DigitalContentAsset.NFTData', {
+                data: struct('A.f8d6e0586b0a20c7.FanTopToken.NFTData', {
                     serialNumber: uint32(2),
                     itemId: string('test-item-id-1'),
                     itemVersion: uint32(1),

--- a/tests/utils/emulator.ts
+++ b/tests/utils/emulator.ts
@@ -68,7 +68,14 @@ export async function createEmulator(): Promise<FlowEmulator> {
         stderr = ''
         const command = 'flow --host ' + host + ' --output json ' + subCommand
         const json = execSync(command).toString()
-        const result = JSON.parse(json)
+
+        let result: any
+        try {
+            result = JSON.parse(json)
+        } catch (err) {
+            console.error(json)
+            throw err
+        }
         if (result.error) {
             throw new Error(result.error)
         }
@@ -79,8 +86,8 @@ export async function createEmulator(): Promise<FlowEmulator> {
         await waitPort({ port, output: 'silent' }).then(open => { if (!open) { throw new Error(port + ' did not open') } })
         execFlow('flow accounts create --key ' + accounts['emulator-user-1'].pubkey)
         execFlow('flow accounts create --key ' + accounts['emulator-user-2'].pubkey)
-        execFlow('flow transactions send transactions/minter/add_public_key.cdc --arg String:' + accounts['minter-1'].key.pubkey)
-        execFlow('flow transactions send transactions/minter/add_public_key.cdc --arg String:' + accounts['minter-2'].key.pubkey)
+        execFlow('flow transactions send transactions/minter/add_public_key.cdc ' + accounts['minter-1'].key.pubkey)
+        execFlow('flow transactions send transactions/minter/add_public_key.cdc ' + accounts['minter-2'].key.pubkey)
         execFlow('flow project deploy')
 
         const emulator: FlowEmulator = {

--- a/transactions/abuse/inject_item_metadata.cdc
+++ b/transactions/abuse/inject_item_metadata.cdc
@@ -1,11 +1,11 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
 
 transaction(itemId: String, key: String, value: String) {
     prepare(account: AuthAccount) {}
 
     execute {
-        let item = DigitalContentAsset.getItem(itemId)
-        let metadata = DigitalContentAsset.getItem(itemId)!.getData().getMetadata()
+        let item = FanTopToken.getItem(itemId)
+        let metadata = FanTopToken.getItem(itemId)!.getData().getMetadata()
         metadata.insert(key: key, value)
     }
 }

--- a/transactions/abuse/inject_item_version.cdc
+++ b/transactions/abuse/inject_item_version.cdc
@@ -1,10 +1,10 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
 
 transaction(itemId: String, version: UInt32, metadata: { String: String }, originSerialNumber: UInt32) {
     prepare(account: AuthAccount) {}
 
     execute {
-        let data = DigitalContentAsset.ItemData(version: version, metadata: metadata, originSerialNumber: 100)
-        DigitalContentAsset.getItem(itemId)?.getVersions()?.insert(key: version, data)
+        let data = FanTopToken.ItemData(version: version, metadata: metadata, originSerialNumber: 100)
+        FanTopToken.getItem(itemId)?.getVersions()?.insert(key: version, data)
     }
 }

--- a/transactions/abuse/update_item_minted_count.cdc
+++ b/transactions/abuse/update_item_minted_count.cdc
@@ -1,10 +1,10 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
 
 transaction(itemId: String, mintedCount: UInt32) {
     prepare(account: AuthAccount) {}
 
     execute {
-        let item = DigitalContentAsset.getItem(itemId)!
+        let item = FanTopToken.getItem(itemId)!
         item.mintedCount = mintedCount
     }
 }

--- a/transactions/abuse/update_nft_data.cdc
+++ b/transactions/abuse/update_nft_data.cdc
@@ -1,11 +1,11 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
 
 transaction(address: Address, nftID: UInt64) {
     prepare(account: AuthAccount) {}
 
     execute {
-        let collectionRef = getAccount(address).getCapability(DigitalContentAsset.collectionPublicPath).borrow<&{DigitalContentAsset.CollectionPublic}>()!
-        let tokenRef = collectionRef.borrowDCAToken(id: nftID)!
+        let collectionRef = getAccount(address).getCapability(FanTopToken.collectionPublicPath).borrow<&{FanTopToken.CollectionPublic}>()!
+        let tokenRef = collectionRef.borrowFanTopToken(id: nftID)!
         tokenRef.getData().getMetadata().insert(key: "injected", "injected!!")
     }
 }

--- a/transactions/admin/add_minter.cdc
+++ b/transactions/admin/add_minter.cdc
@@ -1,14 +1,14 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
-import DCAPermission from "../../contracts/DCAPermission.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
+import FanTopPermission from "../../contracts/FanTopPermission.cdc"
 
 transaction(receiver: Address) {
-    let adminRef: &DCAPermission.Admin
-    let receiverRef: &AnyResource{DCAPermission.Receiver}
+    let adminRef: &FanTopPermission.Admin
+    let receiverRef: &AnyResource{FanTopPermission.Receiver}
 
     prepare(account: AuthAccount) {
-        self.adminRef = account.borrow<&DCAPermission.Holder>(from: DCAPermission.receiverStoragePath)?.borrowAdmin(by: account)
+        self.adminRef = account.borrow<&FanTopPermission.Holder>(from: FanTopPermission.receiverStoragePath)?.borrowAdmin(by: account)
             ?? panic("No admin in storage")
-        self.receiverRef = getAccount(receiver).getCapability(DCAPermission.receiverPublicPath).borrow<&AnyResource{DCAPermission.Receiver}>()
+        self.receiverRef = getAccount(receiver).getCapability(FanTopPermission.receiverPublicPath).borrow<&AnyResource{FanTopPermission.Receiver}>()
             ?? panic("No permission receiver in storage")
     }
 

--- a/transactions/admin/add_operator.cdc
+++ b/transactions/admin/add_operator.cdc
@@ -1,14 +1,14 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
-import DCAPermission from "../../contracts/DCAPermission.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
+import FanTopPermission from "../../contracts/FanTopPermission.cdc"
 
 transaction(receiver: Address) {
-    let adminRef: &DCAPermission.Admin
-    let receiverRef: &AnyResource{DCAPermission.Receiver}
+    let adminRef: &FanTopPermission.Admin
+    let receiverRef: &AnyResource{FanTopPermission.Receiver}
 
     prepare(account: AuthAccount) {
-        self.adminRef = account.borrow<&DCAPermission.Holder>(from: DCAPermission.receiverStoragePath)?.borrowAdmin(by: account)
+        self.adminRef = account.borrow<&FanTopPermission.Holder>(from: FanTopPermission.receiverStoragePath)?.borrowAdmin(by: account)
             ?? panic("No admin in storage")
-        self.receiverRef = getAccount(receiver).getCapability(DCAPermission.receiverPublicPath).borrow<&AnyResource{DCAPermission.Receiver}>()
+        self.receiverRef = getAccount(receiver).getCapability(FanTopPermission.receiverPublicPath).borrow<&AnyResource{FanTopPermission.Receiver}>()
             ?? panic("No permission receiver in storage")
     }
 

--- a/transactions/admin/remove_minter.cdc
+++ b/transactions/admin/remove_minter.cdc
@@ -1,11 +1,11 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
-import DCAPermission from "../../contracts/DCAPermission.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
+import FanTopPermission from "../../contracts/FanTopPermission.cdc"
 
 transaction(receiver: Address) {
-    let adminRef: &DCAPermission.Admin
+    let adminRef: &FanTopPermission.Admin
 
     prepare(account: AuthAccount) {
-        self.adminRef = account.borrow<&DCAPermission.Holder>(from: DCAPermission.receiverStoragePath)?.borrowAdmin(by: account)
+        self.adminRef = account.borrow<&FanTopPermission.Holder>(from: FanTopPermission.receiverStoragePath)?.borrowAdmin(by: account)
             ?? panic("No admin in storage")
     }
 

--- a/transactions/admin/remove_operator.cdc
+++ b/transactions/admin/remove_operator.cdc
@@ -1,11 +1,11 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
-import DCAPermission from "../../contracts/DCAPermission.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
+import FanTopPermission from "../../contracts/FanTopPermission.cdc"
 
 transaction(receiver: Address) {
-    let adminRef: &DCAPermission.Admin
+    let adminRef: &FanTopPermission.Admin
 
     prepare(account: AuthAccount) {
-        self.adminRef = account.borrow<&DCAPermission.Holder>(from: DCAPermission.receiverStoragePath)?.borrowAdmin(by: account)
+        self.adminRef = account.borrow<&FanTopPermission.Holder>(from: FanTopPermission.receiverStoragePath)?.borrowAdmin(by: account)
             ?? panic("No admin in storage")
     }
 

--- a/transactions/minter/batch_mint_token.cdc
+++ b/transactions/minter/batch_mint_token.cdc
@@ -1,16 +1,16 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
-import DCAPermission from "../../contracts/DCAPermission.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
+import FanTopPermission from "../../contracts/FanTopPermission.cdc"
 
 // arg: [["ref-id-1", "item-id-1", { "exInfo": "info per token" }], ... ]
 transaction(recipient: Address, args: [[AnyStruct]]) {
-    let minterRef: &DCAPermission.Minter
-    let collectionRef: &{DigitalContentAsset.CollectionPublic}
+    let minterRef: &FanTopPermission.Minter
+    let collectionRef: &{FanTopToken.CollectionPublic}
 
     prepare(account: AuthAccount) {
-        self.minterRef = account.borrow<&DCAPermission.Holder>(from: DCAPermission.receiverStoragePath)?.borrowMinter(by: account)
+        self.minterRef = account.borrow<&FanTopPermission.Holder>(from: FanTopPermission.receiverStoragePath)?.borrowMinter(by: account)
             ?? panic("No minter in storage")
-        self.collectionRef = getAccount(recipient).getCapability<&{DigitalContentAsset.CollectionPublic}>(DigitalContentAsset.collectionPublicPath).borrow()
-            ?? panic("Cannot borrow a reference to the DCA collection")
+        self.collectionRef = getAccount(recipient).getCapability<&{FanTopToken.CollectionPublic}>(FanTopToken.collectionPublicPath).borrow()
+            ?? panic("Cannot borrow a reference to the FanTopToken collection")
     }
 
     execute {
@@ -22,7 +22,7 @@ transaction(recipient: Address, args: [[AnyStruct]]) {
 
             assert(!refIds.contains(refId), message: "NFT with duplicate refId is not issued")
 
-            let item = DigitalContentAsset.getItem(itemId) ?? panic("That itemId does not exist")
+            let item = FanTopToken.getItem(itemId) ?? panic("That itemId does not exist")
             let itemVersion = item.version
 
             let token <- self.minterRef.mintToken(

--- a/transactions/minter/mint_token.cdc
+++ b/transactions/minter/mint_token.cdc
@@ -1,19 +1,19 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
-import DCAPermission from "../../contracts/DCAPermission.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
+import FanTopPermission from "../../contracts/FanTopPermission.cdc"
 
 transaction(recipient: Address, refId: String, itemId: String, metadata: { String: String }) {
-    let minterRef: &DCAPermission.Minter
-    let collectionRef: &{DigitalContentAsset.CollectionPublic}
+    let minterRef: &FanTopPermission.Minter
+    let collectionRef: &{FanTopToken.CollectionPublic}
 
     prepare(account: AuthAccount) {
-        self.minterRef = account.borrow<&DCAPermission.Holder>(from: DCAPermission.receiverStoragePath)?.borrowMinter(by: account)
+        self.minterRef = account.borrow<&FanTopPermission.Holder>(from: FanTopPermission.receiverStoragePath)?.borrowMinter(by: account)
             ?? panic("No minter in storage")
-        self.collectionRef = getAccount(recipient).getCapability<&{DigitalContentAsset.CollectionPublic}>(DigitalContentAsset.collectionPublicPath).borrow()
-            ?? panic("Cannot borrow a reference to the DCA collection")
+        self.collectionRef = getAccount(recipient).getCapability<&{FanTopToken.CollectionPublic}>(FanTopToken.collectionPublicPath).borrow()
+            ?? panic("Cannot borrow a reference to the FanTopToken collection")
     }
 
     execute {
-        let item = DigitalContentAsset.getItem(itemId) ?? panic("That itemId does not exist")
+        let item = FanTopToken.getItem(itemId) ?? panic("That itemId does not exist")
 
         let itemId = itemId
         let itemVersion = item.version

--- a/transactions/operator/create_item.cdc
+++ b/transactions/operator/create_item.cdc
@@ -1,11 +1,11 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
-import DCAPermission from "../../contracts/DCAPermission.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
+import FanTopPermission from "../../contracts/FanTopPermission.cdc"
 
 transaction(itemId: String, version: UInt32, limit: UInt32, metadata: { String: String }, active: Bool) {
-    let operatorRef: &DCAPermission.Operator
+    let operatorRef: &FanTopPermission.Operator
 
     prepare(account: AuthAccount) {
-        self.operatorRef = account.borrow<&DCAPermission.Holder>(from: DCAPermission.receiverStoragePath)?.borrowOperator(by: account)
+        self.operatorRef = account.borrow<&FanTopPermission.Holder>(from: FanTopPermission.receiverStoragePath)?.borrowOperator(by: account)
             ?? panic("No operator in storage")
     }
 
@@ -14,13 +14,13 @@ transaction(itemId: String, version: UInt32, limit: UInt32, metadata: { String: 
     }
 
     post {
-        DigitalContentAsset.getItem(itemId) != nil: "Item must be added"
-        DigitalContentAsset.getItem(itemId)!.itemId == itemId: "itemId must match"
-        DigitalContentAsset.getItem(itemId)!.limit == limit: "limit must match"
-        DigitalContentAsset.getItem(itemId)!.version == version: "version must match"
-        DigitalContentAsset.getItem(itemId)!.mintedCount == 0: "mintedCount must be zero"
-        !DigitalContentAsset.getItem(itemId)!.isVersionLocked(): "item version must not be locked"
-        equalsStringDictionary(DigitalContentAsset.getItem(itemId)!.getData().getMetadata(), metadata): "metadata must match"
+        FanTopToken.getItem(itemId) != nil: "Item must be added"
+        FanTopToken.getItem(itemId)!.itemId == itemId: "itemId must match"
+        FanTopToken.getItem(itemId)!.limit == limit: "limit must match"
+        FanTopToken.getItem(itemId)!.version == version: "version must match"
+        FanTopToken.getItem(itemId)!.mintedCount == 0: "mintedCount must be zero"
+        !FanTopToken.getItem(itemId)!.isVersionLocked(): "item version must not be locked"
+        equalsStringDictionary(FanTopToken.getItem(itemId)!.getData().getMetadata(), metadata): "metadata must match"
     }
 }
 

--- a/transactions/operator/update_item_active.cdc
+++ b/transactions/operator/update_item_active.cdc
@@ -1,11 +1,11 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
-import DCAPermission from "../../contracts/DCAPermission.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
+import FanTopPermission from "../../contracts/FanTopPermission.cdc"
 
 transaction(itemId: String, active: Bool) {
-    let operatorRef: &DCAPermission.Operator
+    let operatorRef: &FanTopPermission.Operator
 
     prepare(account: AuthAccount) {
-        self.operatorRef = account.borrow<&DCAPermission.Holder>(from: DCAPermission.receiverStoragePath)?.borrowOperator(by: account)
+        self.operatorRef = account.borrow<&FanTopPermission.Holder>(from: FanTopPermission.receiverStoragePath)?.borrowOperator(by: account)
             ?? panic("No operator in storage")
     }
 

--- a/transactions/operator/update_item_limit.cdc
+++ b/transactions/operator/update_item_limit.cdc
@@ -1,11 +1,11 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
-import DCAPermission from "../../contracts/DCAPermission.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
+import FanTopPermission from "../../contracts/FanTopPermission.cdc"
 
 transaction(itemId: String, limit: UInt32) {
-    let operatorRef: &DCAPermission.Operator
+    let operatorRef: &FanTopPermission.Operator
 
     prepare(account: AuthAccount) {
-        self.operatorRef = account.borrow<&DCAPermission.Holder>(from: DCAPermission.receiverStoragePath)?.borrowOperator(by: account)
+        self.operatorRef = account.borrow<&FanTopPermission.Holder>(from: FanTopPermission.receiverStoragePath)?.borrowOperator(by: account)
             ?? panic("No operator in storage")
     }
 

--- a/transactions/operator/update_item_metadata.cdc
+++ b/transactions/operator/update_item_metadata.cdc
@@ -1,11 +1,11 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
-import DCAPermission from "../../contracts/DCAPermission.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
+import FanTopPermission from "../../contracts/FanTopPermission.cdc"
 
 transaction(itemId: String, version: UInt32, metadata: { String: String }) {
-    let operatorRef: &DCAPermission.Operator
+    let operatorRef: &FanTopPermission.Operator
 
     prepare(account: AuthAccount) {
-        self.operatorRef = account.borrow<&DCAPermission.Holder>(from: DCAPermission.receiverStoragePath)?.borrowOperator(by: account)
+        self.operatorRef = account.borrow<&FanTopPermission.Holder>(from: FanTopPermission.receiverStoragePath)?.borrowOperator(by: account)
             ?? panic("No operator in storage")
     }
 

--- a/transactions/owner/add_admin.cdc
+++ b/transactions/owner/add_admin.cdc
@@ -1,14 +1,14 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
-import DCAPermission from "../../contracts/DCAPermission.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
+import FanTopPermission from "../../contracts/FanTopPermission.cdc"
 
 transaction(receiver: Address) {
-    let ownerRef: &DCAPermission.Owner
-    let receiverRef: &AnyResource{DCAPermission.Receiver}
+    let ownerRef: &FanTopPermission.Owner
+    let receiverRef: &AnyResource{FanTopPermission.Receiver}
 
     prepare(owner: AuthAccount) {
-        self.ownerRef = owner.borrow<&DCAPermission.Owner>(from: /storage/DCAOwner)
+        self.ownerRef = owner.borrow<&FanTopPermission.Owner>(from: /storage/FanTopOwner)
             ?? panic("No owner resource in storage")
-        self.receiverRef = getAccount(receiver).getCapability(DCAPermission.receiverPublicPath).borrow<&AnyResource{DCAPermission.Receiver}>()
+        self.receiverRef = getAccount(receiver).getCapability(FanTopPermission.receiverPublicPath).borrow<&AnyResource{FanTopPermission.Receiver}>()
             ?? panic("No permission receiver in storage")
     }
 

--- a/transactions/owner/remove_admin.cdc
+++ b/transactions/owner/remove_admin.cdc
@@ -1,15 +1,15 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
-import DCAPermission from "../../contracts/DCAPermission.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
+import FanTopPermission from "../../contracts/FanTopPermission.cdc"
 
 transaction(receiver: Address) {
-    let ownerRef: &DCAPermission.Owner
+    let ownerRef: &FanTopPermission.Owner
 
     prepare(owner: AuthAccount) {
-        self.ownerRef = owner.borrow<&DCAPermission.Owner>(from: /storage/DCAOwner)
+        self.ownerRef = owner.borrow<&FanTopPermission.Owner>(from: /storage/FanTopOwner)
             ?? panic("No owner resource in storage")
     }
 
     execute {
-        self.ownerRef.removePermission(address: receiver, as: DCAPermission.Role.admin)
+        self.ownerRef.removePermission(address: receiver, as: FanTopPermission.Role.admin)
     }
 }

--- a/transactions/owner/remove_minter.cdc
+++ b/transactions/owner/remove_minter.cdc
@@ -1,15 +1,15 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
-import DCAPermission from "../../contracts/DCAPermission.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
+import FanTopPermission from "../../contracts/FanTopPermission.cdc"
 
 transaction(receiver: Address) {
-    let ownerRef: &DCAPermission.Owner
+    let ownerRef: &FanTopPermission.Owner
 
     prepare(owner: AuthAccount) {
-        self.ownerRef = owner.borrow<&DCAPermission.Owner>(from: /storage/DCAOwner)
+        self.ownerRef = owner.borrow<&FanTopPermission.Owner>(from: /storage/FanTopOwner)
             ?? panic("No owner resource in storage")
     }
 
     execute {
-        self.ownerRef.removePermission(address: receiver, as: DCAPermission.Role.minter)
+        self.ownerRef.removePermission(address: receiver, as: FanTopPermission.Role.minter)
     }
 }

--- a/transactions/owner/remove_operator.cdc
+++ b/transactions/owner/remove_operator.cdc
@@ -1,15 +1,15 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
-import DCAPermission from "../../contracts/DCAPermission.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
+import FanTopPermission from "../../contracts/FanTopPermission.cdc"
 
 transaction(receiver: Address) {
-    let ownerRef: &DCAPermission.Owner
+    let ownerRef: &FanTopPermission.Owner
 
     prepare(owner: AuthAccount) {
-        self.ownerRef = owner.borrow<&DCAPermission.Owner>(from: /storage/DCAOwner)
+        self.ownerRef = owner.borrow<&FanTopPermission.Owner>(from: /storage/FanTopOwner)
             ?? panic("No owner resource in storage")
     }
 
     execute {
-        self.ownerRef.removePermission(address: receiver, as: DCAPermission.Role.operator)
+        self.ownerRef.removePermission(address: receiver, as: FanTopPermission.Role.operator)
     }
 }

--- a/transactions/permission/destroy_permission_receiver.cdc
+++ b/transactions/permission/destroy_permission_receiver.cdc
@@ -1,9 +1,9 @@
-import DCAPermission from "../../contracts/DCAPermission.cdc"
+import FanTopPermission from "../../contracts/FanTopPermission.cdc"
 
 transaction {
     prepare(account: AuthAccount) {
-        let holder <- account.load<@DCAPermission.Holder>(from: DCAPermission.receiverStoragePath) ?? panic("The account does not have a permission holder.")
+        let holder <- account.load<@FanTopPermission.Holder>(from: FanTopPermission.receiverStoragePath) ?? panic("The account does not have a permission holder.")
         destroy holder
-        account.unlink(DCAPermission.receiverPublicPath)
+        account.unlink(FanTopPermission.receiverPublicPath)
     }
 }

--- a/transactions/permission/init_permission_receiver.cdc
+++ b/transactions/permission/init_permission_receiver.cdc
@@ -1,13 +1,13 @@
-import DCAPermission from "../../contracts/DCAPermission.cdc"
+import FanTopPermission from "../../contracts/FanTopPermission.cdc"
 
 transaction {
     prepare(account: AuthAccount) {
-        if account.borrow<&DCAPermission.Holder>(from: DCAPermission.receiverStoragePath) != nil {
+        if account.borrow<&FanTopPermission.Holder>(from: FanTopPermission.receiverStoragePath) != nil {
             panic("The account has already been initialized.")
         }
 
-        let holder <- DCAPermission.createHolder(account: account)
-        account.save(<-holder, to: DCAPermission.receiverStoragePath)
-        account.link<&AnyResource{DCAPermission.Receiver}>(DCAPermission.receiverPublicPath, target: DCAPermission.receiverStoragePath)
+        let holder <- FanTopPermission.createHolder(account: account)
+        account.save(<-holder, to: FanTopPermission.receiverStoragePath)
+        account.link<&AnyResource{FanTopPermission.Receiver}>(FanTopPermission.receiverPublicPath, target: FanTopPermission.receiverStoragePath)
     }
 }

--- a/transactions/user/destroy_account.cdc
+++ b/transactions/user/destroy_account.cdc
@@ -1,8 +1,8 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
 
 transaction {
     prepare(acct: AuthAccount) {
-        let collection <- acct.load<@DigitalContentAsset.Collection>(from: DigitalContentAsset.collectionStoragePath)
+        let collection <- acct.load<@FanTopToken.Collection>(from: FanTopToken.collectionStoragePath)
             ?? panic("That account has not been initialized.")
         destroy collection
     }

--- a/transactions/user/init_account.cdc
+++ b/transactions/user/init_account.cdc
@@ -1,13 +1,13 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
 
 transaction {
     prepare(acct: AuthAccount) {
-        if acct.borrow<&DigitalContentAsset.Collection>(from: DigitalContentAsset.collectionStoragePath) != nil {
+        if acct.borrow<&FanTopToken.Collection>(from: FanTopToken.collectionStoragePath) != nil {
             panic("The account has already been initialized.")
         }
 
-        let collection <- DigitalContentAsset.createEmptyCollection() as! @DigitalContentAsset.Collection
-        acct.save(<-collection, to: DigitalContentAsset.collectionStoragePath)
-        acct.link<&{DigitalContentAsset.CollectionPublic}>(DigitalContentAsset.collectionPublicPath, target: DigitalContentAsset.collectionStoragePath)
+        let collection <- FanTopToken.createEmptyCollection() as! @FanTopToken.Collection
+        acct.save(<-collection, to: FanTopToken.collectionStoragePath)
+        acct.link<&{FanTopToken.CollectionPublic}>(FanTopToken.collectionPublicPath, target: FanTopToken.collectionStoragePath)
     }
 }

--- a/transactions/user/transfer_token.cdc
+++ b/transactions/user/transfer_token.cdc
@@ -1,16 +1,16 @@
-import DigitalContentAsset from "../../contracts/DigitalContentAsset.cdc"
+import FanTopToken from "../../contracts/FanTopToken.cdc"
 import NonFungibleToken from "../../contracts/NonFungibleToken.cdc"
 
 transaction(id: UInt64, to: Address) {
     let transferToken: @NonFungibleToken.NFT
 
     prepare(from: AuthAccount) {
-        let fromRef = from.borrow<&DigitalContentAsset.Collection>(from: DigitalContentAsset.collectionStoragePath)!
+        let fromRef = from.borrow<&FanTopToken.Collection>(from: FanTopToken.collectionStoragePath)!
         self.transferToken <- fromRef.withdraw(withdrawID: id)
     }
 
     execute {
-        let toRef = getAccount(to).getCapability(DigitalContentAsset.collectionPublicPath).borrow<&{DigitalContentAsset.CollectionPublic}>()!
+        let toRef = getAccount(to).getCapability(FanTopToken.collectionPublicPath).borrow<&{FanTopToken.CollectionPublic}>()!
         toRef.deposit(token: <- self.transferToken)
     }
 }


### PR DESCRIPTION
Renamed the contract name for release to mainnet.
Does not include functional changes

* DigitalContentAsset.cdc -> FanTopToken.cdc
* /storage/DCACollection -> FanTopTokenCollection
* DCAPermission -> FanTopPermission

